### PR TITLE
Fake record adapter

### DIFF
--- a/spec/support/fake_record.rb
+++ b/spec/support/fake_record.rb
@@ -66,7 +66,7 @@ module FakeRecord
     attr_reader :spec
 
     def initialize
-      @spec = Spec.new('sqlite3')
+      @spec = Spec.new(:adapter => 'sqlite3')
     end
 
     def connection


### PR DESCRIPTION
While trying to get adapter for Engine config was `String` type instead of `Hash`. Under ruby 1.8.7 it silently returns `nil` while ruby 1.9.2 throws `can't convert Symbol into Integer (TypeError)`
