### PR TITLE
Tracking recent In change in NotIn

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -202,8 +202,9 @@ module Arel
 
       def visit_Arel_Nodes_NotIn o
         right = o.right
-        right = right.empty? ? 'NULL' : right.map { |x| visit x }.join(', ')
-        "#{visit o.left} NOT IN (#{right})"
+        "#{visit o.left} NOT IN (#{
+          right.empty? ? 'NULL' : right.map { |x| visit x }.join(', ')
+        })"
       end
 
       def visit_Arel_Nodes_And o


### PR DESCRIPTION
Noticed the update to avoid modifying the array supplied to right side of In, and made the same change to NotIn. Not being used in Rails so probably not going to generate any tickets, but better to stay consistent, I think.

On a side note, since there's no such thing as NOT IN (NULL), is there some other sensible fallback? NOT IN ()?
