### PR TITLE
spec tests were not working properly

### DIFF
--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,4 +1,1 @@
 require "support/matchers/be_like"
-require "support/matchers/disambiguate_attributes"
-require "support/matchers/hash_the_same_as"
-require "support/matchers/have_rows"


### PR DESCRIPTION
Due to the fact that there are missing matchers being referenced in the matchers.rb stub.
