### PR TITLE
  Created syntactic sugar Table(...) method

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+== 2.0.0 / 2010-08-01
+* Enhancements
+  
+  * Recreate library using the Visitor pattern.
+    http://en.wikipedia.org/wiki/Visitor_pattern
+
 == 0.3.0 / 2010-03-10
 
 * Enhancements

--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -1,4 +1,8 @@
-module Arel
+def Table(name, engine = Arel::Table.engine)
+  Arel::Table.new(name, engine)
+end
+
+module Arel 
   class Table
     include Arel::Crud
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1,6 +1,27 @@
 require 'spec_helper'
 
-module Arel
+describe '#Table' do
+  it 'creates a base relation variable' do
+    name = :foo
+    Table(name) == Arel::Table.new(name)
+  end
+  
+  it 'should have a default engine' do
+    Table(:foo).engine.should == Arel::Table.engine  
+  end
+  
+  it 'can take an engine' do
+    engine = Arel::Table.engine
+    Table(:foo, engine).engine.should be engine
+  end
+  it 'can take an options hash' do
+    engine = Arel::Table.engine
+    options = { :engine => engine }
+    Table(:foo, options).engine.should be engine
+  end
+end
+
+module Arel 
   describe Table do
     before do
       @relation = Table.new(:users)


### PR DESCRIPTION
All documentation on Arel seems to use this method of implementing a base relationship (including the README).  I figured it doesn't hurt to have and it's fully tested.

The next question is, what are the repercussions of having this be in the global namespace (a-la arel 1.0) or should it be Arel::Table(:thing)  I vote for it not to be namespaced.

More to come.
