### PR TITLE
Bignum support for Arel::Visitors::ToSql

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -263,6 +263,7 @@ module Arel
       def visit_Fixnum o; o end
       alias :visit_Arel_Nodes_SqlLiteral :visit_Fixnum
       alias :visit_Arel_SqlLiteral :visit_Fixnum # This is deprecated
+      alias :visit_Bignum :visit_Fixnum
 
       def visit_String o; quote(o, @last_column) end
 

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -29,6 +29,10 @@ module Arel
         @visitor.accept 2.14
       end
 
+      it "should visit_Bignum" do
+        @visitor.accept 8787878092
+      end
+
       it "should visit_Hash" do
         @visitor.accept({:a => 1})
       end


### PR DESCRIPTION
Hi there,

when migrating on older rails app to rails.git I've noticed the missing support of bignum. So here is the patch.

Cheers
