### PR TITLE
NilClass visitor in ToSql

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -277,6 +277,7 @@ module Arel
       alias :visit_Symbol :visit_String
       alias :visit_Time :visit_String
       alias :visit_TrueClass :visit_String
+      alias :visit_NilClass :visit_String
 
       def quote value, column = nil
         @connection.quote value, column

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -45,6 +45,10 @@ module Arel
         @visitor.accept Date.today
       end
 
+      it "should visit_NilClass" do
+        @visitor.accept(nil).must_be_like "NULL"
+      end
+
       it "should visit_Arel_Nodes_And" do
         node = Nodes::And.new @attr.eq(10), @attr.eq(11)
         @visitor.accept(node).must_be_like %{


### PR DESCRIPTION
Looks like we're missing a NilClass visitor in ToSql, though it's in the Dot visitor. This is just a quickie patch to add it.
