### PR TITLE
Fix for setting table names across schema boundaries for MySQL

### DIFF
--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -26,6 +26,10 @@ module Arel
       end
     end
 
+    def true_table_name(name)
+      name.to_s.gsub(/.*\./, '')
+    end
+
     def primary_key
       @primary_key ||= begin
         primary_key_name = @engine.connection.primary_key(name)
@@ -115,7 +119,7 @@ module Arel
     end
 
     def table_exists?
-      @table_exists ||= tables.key?(@name) || engine.connection.table_exists?(name)
+      @table_exists ||= tables.key?(true_table_name(@name)) || engine.connection.table_exists?(name)
     end
 
     def tables

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -188,6 +188,13 @@ module Arel
           Table.table_cache(relation.engine).key?(relation.name).must_equal true
         end
       end
+
+      it 'should pass existence test even if its prefixed by a schema name' do
+        [ 'second_db.users' ].each do |name|
+          relation = Table.new name
+          relation.send(:table_exists?).must_equal true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is MySQL specific so perhaps it should go somewhere else.  I've also uploaded  a Rails 3 app that demonstrates this bug. 

https://github.com/davidyang/areltest
