### PR TITLE
Make "not" apply to whole expression

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -221,7 +221,7 @@ module Arel
       end
 
       def visit_Arel_Nodes_Not o
-        "NOT #{visit o.expr}"
+        "NOT (#{visit o.expr})"
       end
 
       def visit_Arel_Table o

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -40,7 +40,13 @@ module Arel
 
       it "should visit_Not" do
         sql = @visitor.accept Nodes::Not.new(Arel.sql("foo"))
-        sql.must_be_like "NOT foo"
+        sql.must_be_like "NOT (foo)"
+      end
+
+      it "should apply Not to the whole expression" do
+        node = Nodes::And.new @attr.eq(10), @attr.eq(11)
+        sql = @visitor.accept Nodes::Not.new(node)
+        sql.must_be_like %{NOT ("users"."id" = 10 AND "users"."id" = 11)}
       end
 
       it "should visit_As" do


### PR DESCRIPTION
There is a problem in Arel::Visitors::ToSql.visit_Arel_Nodes_Not in cases where the expression that we're applying "not" to is already a compound expression. Suppose, for instance, that z is a Node that, when visited, will produce:

"users"."first_name" = "Ryan" AND "users"."last_name" = "Rempel"

At the moment, visiting z.not will produce:

NOT "users"."first_name" = "Ryan" AND "users"."last_name" = "Rempel"

But this is wrong ... NOT has higher precedence than AND, so the NOT is only really applying to the first part of the sub-expression. What we need here is:

NOT ("users"."first_name" = "Ryan" AND "users"."last_name" = "Rempel")
