### PR TITLE
added support for the SQL WITH clause

### DIFF
--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -18,6 +18,7 @@ require 'arel/nodes/join_source'
 require 'arel/nodes/ordering'
 require 'arel/nodes/delete_statement'
 require 'arel/nodes/table_alias'
+require 'arel/nodes/with'
 
 # nary
 require 'arel/nodes/and'

--- a/lib/arel/nodes/select_core.rb
+++ b/lib/arel/nodes/select_core.rb
@@ -1,11 +1,12 @@
 module Arel
   module Nodes
     class SelectCore < Arel::Nodes::Node
-      attr_accessor :projections, :wheres, :groups
+      attr_accessor :projections, :wheres, :groups, :withs
       attr_accessor :having, :source
 
       def initialize
         @source      = JoinSource.new nil
+        @withs       = []
         @projections = []
         @wheres      = []
         @groups      = []

--- a/lib/arel/nodes/with.rb
+++ b/lib/arel/nodes/with.rb
@@ -1,0 +1,8 @@
+module Arel
+  module Nodes
+    class With < Arel::Nodes::Binary
+      alias :name :left
+      alias :relation :right
+    end
+  end
+end

--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -77,6 +77,11 @@ module Arel
       self
     end
 
+    def with aliaz, manager
+      aliaz = Nodes::SqlLiteral.new(aliaz) if String === aliaz
+      @ctx.withs << Nodes::With.new(aliaz, manager)
+    end
+
     def froms
       @ast.cores.map { |x| x.from }.compact
     end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -126,6 +126,7 @@ module Arel
 
       def visit_Arel_Nodes_SelectCore o
         [
+          ("WITH #{o.withs.map {|x| visit x}.join(', ')}" unless o.withs.empty?),
           "SELECT #{o.projections.map { |x| visit x }.join ', '}",
           visit(o.source),
           ("WHERE #{o.wheres.map { |x| visit x }.join ' AND ' }" unless o.wheres.empty?),
@@ -187,6 +188,10 @@ module Arel
 
       def visit_Arel_Nodes_TableAlias o
         "#{visit o.relation} #{quote_table_name o.name}"
+      end
+
+      def visit_Arel_Nodes_With o
+        "#{visit o.name} AS (#{o.relation.to_sql})"
       end
 
       def visit_Arel_Nodes_Between o


### PR DESCRIPTION
I added support for the SQL standard WITH clause in this commit.

WITH is commonly used in Postgres and Oracle, but it's not supported in MySQL even though it is part of the ANSI/ISO standard. I'm not sure if sqlite supports it or not. I didn't see any precedent for raising a 'NotSupportedException' or something similar in a specific Visitor subclass, but that could be added to visit_Arel_Nodes_With in the Mysql subclass if desired.

I hope this makes it in to a future release. We're using WITH in several places on one large production app running on Postgres on Heroku.

Thanks,
Nate Clark @ Pivotal Labs Singapore
