### PR TITLE
Allow database specific locking clauses to be used

### DIFF
--- a/lib/arel/nodes/lock.rb
+++ b/lib/arel/nodes/lock.rb
@@ -1,6 +1,10 @@
 module Arel
   module Nodes
     class Lock < Arel::Nodes::Node
+      attr_reader :locking
+      def initialize locking = true
+        @locking = locking
+      end
     end
   end
 end

--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -40,7 +40,7 @@ module Arel
     def lock locking = true
       # FIXME: do we even need to store this?  If locking is +false+ shouldn't
       # we just remove the node from the AST?
-      @ast.lock = Nodes::Lock.new
+      @ast.lock = Nodes::Lock.new(locking)
       self
     end
 

--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -3,7 +3,11 @@ module Arel
     class MySQL < Arel::Visitors::ToSql
       private
       def visit_Arel_Nodes_Lock o
-        "FOR UPDATE"
+        if o.locking.is_a?(String)
+          o.locking
+        else
+          "FOR UPDATE"
+        end
       end
 
       ###

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -3,7 +3,11 @@ module Arel
     class PostgreSQL < Arel::Visitors::ToSql
       private
       def visit_Arel_Nodes_Lock o
-        "FOR UPDATE"
+        if o.locking.is_a?(String)
+          o.locking
+        else
+          "FOR UPDATE"
+        end
       end
 
       def visit_Arel_Nodes_SelectStatement o

--- a/test/visitors/test_mysql.rb
+++ b/test/visitors/test_mysql.rb
@@ -29,11 +29,16 @@ module Arel
         sql.must_be_like "SELECT FROM DUAL"
       end
 
-      it 'uses FOR UPDATE when locking' do
-        stmt = Nodes::SelectStatement.new
-        stmt.lock = Nodes::Lock.new
-        sql = @visitor.accept(stmt)
-        sql.must_be_like "SELECT FROM DUAL FOR UPDATE"
+      describe 'locking' do
+        it 'defaults to FOR UPDATE when locking' do
+          node = Nodes::Lock.new
+          @visitor.accept(node).must_be_like "FOR UPDATE"
+        end
+
+        it 'allows a custom string to be used as a lock' do
+          node = Nodes::Lock.new('LOCK IN SHARE MODE')
+          @visitor.accept(node).must_be_like "LOCK IN SHARE MODE"
+        end
       end
     end
   end

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -7,10 +7,19 @@ module Arel
         @visitor = PostgreSQL.new Table.engine
       end
 
-      it 'should produce a lock value' do
-        @visitor.accept(Nodes::Lock.new).must_be_like %{
-          FOR UPDATE
-        }
+      describe 'locking' do
+        it 'defaults to FOR UPDATE' do
+          @visitor.accept(Nodes::Lock.new).must_be_like %{
+            FOR UPDATE
+          }
+        end
+
+        it 'allows a custom string to be used as a lock' do
+          node = Nodes::Lock.new('FOR SHARE')
+          @visitor.accept(node).must_be_like %{
+            FOR SHARE
+          }
+        end
       end
 
       it "should escape LIMIT" do


### PR DESCRIPTION
Basically just does what it says.

ActiveRecord's docs says that you can pass in a db specific locking clause:

```
 Product.find(1, :lock => 'LOCK IN SHARE MODE')
```

ActiveRecord correctly passes arel a string value, but arel doesn't store it and always uses FOR UPDATE.
