### PR TITLE
Added MINUS for Oracle

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -152,6 +152,7 @@ module Arel
     def except other
       Nodes::Except.new ast, other.ast
     end
+    alias :minus :except
 
     def with *subqueries
       if subqueries.first.is_a? Symbol

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -61,6 +61,10 @@ module Arel
         "raw_rnum_ > #{visit o.expr}"
       end
 
+      def visit_Arel_Nodes_Except o
+        "( #{visit o.left} MINUS #{visit o.right} )"
+      end
+
       ###
       # Hacks for the order clauses specific to Oracle
       def order_hacks o

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -134,6 +134,15 @@ module Arel
         end
 
       end
+
+      it 'modified except to be minus' do
+        left = Nodes::SqlLiteral.new("SELECT * FROM users WHERE age > 10")
+        right = Nodes::SqlLiteral.new("SELECT * FROM users WHERE age > 20")
+        sql = @visitor.accept Nodes::Except.new(left, right)
+        sql.must_be_like %{
+          ( SELECT * FROM users WHERE age > 10 MINUS SELECT * FROM users WHERE age > 20 )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
As pointed out here: https://github.com/brynary/arel/commit/74caeaad157e79853b9c6804f561d3c70eea2346#commitcomment-248453

Oracle has MINUS instead of EXCEPT.

An alias of :minus was also added on SelectManager#except
