### PR TITLE
*_any/*_all modify input

### DIFF
--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -163,6 +163,7 @@ module Arel
     private
 
     def grouping_any method_id, others
+      others = others.dup
       first = send method_id, others.shift
 
       Nodes::Grouping.new others.inject(first) { |memo,expr|
@@ -171,6 +172,7 @@ module Arel
     end
 
     def grouping_all method_id, others
+      others = others.dup
       first = send method_id, others.shift
 
       Nodes::Grouping.new others.inject(first) { |memo,expr|

--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -366,6 +366,14 @@ module Arel
             SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 OR "users"."id" = 2)
           }
         end
+
+        it 'should not eat input' do
+          relation = Table.new(:users)
+          mgr = relation.project relation[:id]
+          values = [1,2]
+          mgr.where relation[:id].eq_any(values)
+          values.must_equal [1,2]
+        end
       end
 
       describe '#eq_all' do
@@ -381,6 +389,14 @@ module Arel
           mgr.to_sql.must_be_like %{
             SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 AND "users"."id" = 2)
           }
+        end
+
+        it 'should not eat input' do
+          relation = Table.new(:users)
+          mgr = relation.project relation[:id]
+          values = [1,2]
+          mgr.where relation[:id].eq_all(values)
+          values.must_equal [1,2]
         end
       end
 


### PR DESCRIPTION
Found a glitch in the grouping_any/grouping_all code today -- it's shifting on an input array.
