### PR TITLE
Prevent Node#not from generating a grouping node

### DIFF
--- a/lib/arel/nodes/node.rb
+++ b/lib/arel/nodes/node.rb
@@ -10,7 +10,7 @@ module Arel
       # Factory method to create a Nodes::Not node that has the recipient of
       # the caller as a child.
       def not
-        Nodes::Not.new Nodes::Grouping.new self
+        Nodes::Not.new self
       end
 
       ###

--- a/test/nodes/test_not.rb
+++ b/test/nodes/test_not.rb
@@ -6,13 +6,10 @@ module Arel
       describe '#not' do
         it 'makes a NOT node' do
           attr = Table.new(:users)[:id]
-          left  = attr.eq(10)
-          right = attr.eq(11)
-          node  = left.or right
-          node.expr.left.must_equal left
-          node.expr.right.must_equal right
-
-          node.or(right).not
+          expr  = attr.eq(10)
+          node  = expr.not
+          node.must_be_kind_of Not
+          node.expr.must_equal expr
         end
       end
     end


### PR DESCRIPTION
Looks like the #not factory method was putting the expression passed in inside a grouping node, but this was unnecessary, since both are unary nodes and the visitor can add parenthesis around the contents if so required. The ToSql visitor does this, in fact, and so all Nots were getting double-enclosed. By removing the needless grouping node, we get a small performance increase, and eliminate ugly extra parens.

Also, I fixed the test while I was in there, since it looks like the #not method test was actually testing #or. :)
