### PR TITLE
Fix for DISTINCT ON on PostgreSQL

### DIFF
--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -42,13 +42,15 @@ module Arel
       end
 
       def aliased_orders orders
-        #orders = o.orders.map { |x| visit x }.join(', ').split(',')
         list = []
         orders.each_with_index do |o,i|
+          # Remove any ASC/DESC modifier and table name if present
+          order_column = o.split.first.split(".").last
+
           list <<
             [
-              "id_list.alias_#{i}",
-              (o.index(/desc/i) && 'DESC')
+             "id_list.#{order_column}",
+             (o.index(/desc/i) && 'DESC')
             ].compact.join(' ')
         end
         list

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -32,6 +32,20 @@ module Arel
         assert_equal 1, sql.scan(/LIMIT/).length, 'should have one limit'
       end
 
+      describe "DISTINCT ON with ORDER BY" do
+        before do
+          sc = Arel::Nodes::SelectStatement.new
+          sc.cores.first.projections << "DISTINCT ON(table.omg) table.*"
+          sc.orders << "table.abc ASC"
+          sc.orders << "xyz DESC"
+          @sql =  @visitor.accept(sc)
+        end
+
+        it "should rename order columns table prefix to match subquery alias" do
+          assert_match(/ORDER BY id_list.abc, id_list.xyz DESC/, @sql)
+          assert_equal 1, @sql.scan(/ORDER BY/).length, "should have one order by"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently for queries with DISTINCT ON and ORDER BY the generated SQL is incorrect - it renames order columns in outer query with **id_list.alias_#{i}**, but these aliases are not specified anywhere.

```
Country.select("DISTINCT ON(countries.id) countries.*").order("countries.name").to_sql 
=> "SELECT * FROM (SELECT DISTINCT ON(countries.id) countries.* FROM \"countries\") AS id_list ORDER BY id_list.alias_0"
```

This patch modifies Arel::Visitors::PostgreSQL#aliased_orders method, so that the query above returns:

```
=> "SELECT * FROM (SELECT DISTINCT ON(countries.id) countries.* FROM \"countries\") AS id_list ORDER BY id_list.name"
```

which works fine.

This issue originally was reported here: https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6450 
I'm not 100% sure if this will work in all cases, becuase in ActiveRecord PostgreSQL adapter I found similar code to the original one with column aliases, so maybe there's some deeper meaning in it :)

It's currently less important, but it might be possible to optimize it slightly in the future - according to PostgreSQL docs, a subquery is only necessary if DISTINCT ON expression doesn't match the leftmost ORDER BY expression.
