### PR TITLE
"WHERE" clauses were being ignored in UpdateManager

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -35,6 +35,7 @@ module Arel
         stmt             = Nodes::SelectStatement.new
         core             = stmt.cores.first
         core.froms       = o.relation
+        core.wheres      = o.wheres
         core.projections = [key]
         stmt.limit       = o.limit
         stmt.orders      = o.orders


### PR DESCRIPTION
This supposedly fixes bug [#6058](https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/6058-update_all-ignores-conditions-when-orders-and-limit-options-are-supplied). I also added a test case for this.

Whenever the UpdateManager generates a subquery (usually due to the presence of the order/limit clauses), the where clauses were not passed on to it, so they were ignored.
