### PR TITLE
String -> SqlLiteral in as nodes

### DIFF
--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -1,7 +1,7 @@
 module Arel
   module Predications
     def as other
-      Nodes::As.new self, other
+      Nodes::As.new self, Nodes::SqlLiteral.new(other)
     end
 
     def not_eq other

--- a/test/nodes/test_as.rb
+++ b/test/nodes/test_as.rb
@@ -10,6 +10,12 @@ module Arel
           assert_equal attr, as.left
           assert_equal 'foo', as.right
         end
+
+        it 'converts right to SqlLiteral if a string' do
+          attr = Table.new(:users)[:id]
+          as = attr.as('foo')
+          assert_kind_of Arel::Nodes::SqlLiteral, as.right
+        end
       end
     end
   end


### PR DESCRIPTION
Here you go -- not sure if we care about the possibility of an SqlLiteral.new(<some SqlLiteral>) .

Couldn't just indiscriminately do a to_s on the right because of "as subquery" behavior with unions.
