### PR TITLE
Possible refactor of 2b27e65

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -38,8 +38,8 @@ module Arel
       Arel::Nodes::Exists.new @ast
     end
 
-    def as node, expr
-      Arel::Nodes::As.new node, expr
+    def as other
+      Nodes::As.new grouping(@ast), Nodes::SqlLiteral.new(other)
     end
 
     def where_clauses

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -91,6 +91,22 @@ module Arel
         end
       end
 
+      describe 'as' do
+        it 'makes an AS node by grouping the AST' do
+          manager = Arel::SelectManager.new Table.engine
+          as = manager.as(Arel.sql('foo'))
+          assert_kind_of Arel::Nodes::Grouping, as.left
+          assert_equal manager.ast, as.left.expr
+          assert_equal 'foo', as.right
+        end
+
+        it 'converts right to SqlLiteral if a string' do
+          manager = Arel::SelectManager.new Table.engine
+          as = manager.as('foo')
+          assert_kind_of Arel::Nodes::SqlLiteral, as.right
+        end
+      end
+
       describe 'from' do
         it 'ignores strings when table of same name exists' do
           table   = Table.new :users
@@ -111,8 +127,8 @@ module Arel
           manager2.from table
 
           manager1.project Arel.sql('lol')
-          as = manager2.as manager2.grouping(manager2.ast), Arel.sql('omg')
-          manager1.from as
+          as = manager2.as Arel.sql('omg')
+          manager1.from(as)
 
           manager1.to_sql.must_be_like %{
             SELECT lol FROM (SELECT * FROM "users" ) AS omg


### PR DESCRIPTION
@tenderlove this seems like it hews a little more closely to the style of [the #as method from predications.rb](https://github.com/rails/arel/blob/master/lib/arel/predications.rb#L3-5) to me.  Does this make sense?

I've got an updated version of the [ActiveRecord limited count patch](https://github.com/rails/rails/pull/201) that relies on this patch I'll push up in a sec when the rails test suite finishes running.  Or if SelectManager#as wants to behave as-is, I'll rework my AR patch a bit.

Thanks!
