### PR TITLE
Passing nil in array generates improper SQL

### DIFF
--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -41,7 +41,17 @@ module Arel
           Nodes::Between.new(self, Nodes::And.new([other.begin, other.end]))
         end
       else
-        Nodes::In.new self, other
+        if other.include?(nil)
+          if other.size > 1
+            set  = Nodes::In.new self, other.compact
+            null = Nodes::Equality.new self, nil
+            Nodes::Or.new set, null
+          else
+            Nodes::Equality.new self, nil
+          end
+        else
+          Nodes::In.new self, other
+        end
       end
     end
 


### PR DESCRIPTION
Currently **Arel** generate a pretty odd queue when working with an array containing `nil` value. This commit fixes the problem (which exists, from my perspective).

When calling:

```
where(:field => [1, 2, 3, nil])
```

the following SQL is generated:

```
field IN (1, 2, 3, NULL)
```

while it should be more sqlish and look like

```
field IN (1, 2, 3) OR field IS NULL
```

This issue is affiliated with this [pull](https://github.com/rails/rails/pull/220) (rails repo) request, which brought tests.
