### PR TITLE
Do a strict case sensitive search for Equality and NotEqual Node

### DIFF
--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -29,6 +29,27 @@ module Arel
         ].compact.join ' '
       end
 
+      # Force MySQL to always do a case sensitive search on equality
+      def visit_Arel_Nodes_Equality o
+        right = o.right
+
+        if right.nil?
+          "#{visit o.left} IS NULL"
+        else
+          "#{visit o.left} = BINARY #{visit right}"
+        end
+      end
+
+      # Force MySQL to always do a case sensitive search on inequality
+      def visit_Arel_Nodes_NotEqual o
+        right = o.right
+
+        if right.nil?
+          "#{visit o.left} IS NOT NULL"
+        else
+          "#{visit o.left} != BINARY #{visit right}"
+        end
+      end
     end
   end
 end

--- a/test/visitors/test_mysql.rb
+++ b/test/visitors/test_mysql.rb
@@ -40,6 +40,16 @@ module Arel
           @visitor.accept(node).must_be_like "LOCK IN SHARE MODE"
         end
       end
+
+      it 'uses BINARY on equality test' do
+        node = Nodes::Equality.new("name", "foo")
+        @visitor.accept(node).must_be_like "'name' = BINARY 'foo'"
+      end
+
+      it 'uses BINARY on inequality test' do
+        node = Nodes::NotEqual.new("name", "foo")
+        @visitor.accept(node).must_be_like "'name' != BINARY 'foo'"
+      end
     end
   end
 end


### PR DESCRIPTION
It turns out that MySQL will do a case insensitive match on equal (=) sign. For consistency, we should force it to do a case sensitive match on Equality. To do a case insensitive match you'd then need to use Matches node instead.
