### PR TITLE
Bug in SelectManager cloning breaks clone semantics

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -9,6 +9,11 @@ module Arel
       from table
     end
 
+    def initialize_copy other
+      super
+      @ctx = @ast.cores.last
+    end
+
     def limit
       @ast.limit && @ast.limit.expr
     end

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -187,6 +187,16 @@ module Arel
         m2.project "foo"
         mgr.to_sql.wont_equal m2.to_sql
       end
+
+      it 'makes updates to the correct copy' do
+        table   = Table.new :users, :engine => Table.engine, :as => 'foo'
+        mgr = table.from table
+        m2 = mgr.clone
+        m3 = m2.clone
+        m2.project "foo"
+        mgr.to_sql.wont_equal m2.to_sql
+        m3.to_sql.must_equal mgr.to_sql
+      end
     end
 
     describe 'initialize' do


### PR DESCRIPTION
The attached fixes an issue with cloning queries. Clones were retaining the old context, causing subsequent changes to the new object to be applied to the old.
