### PR TITLE
replace 'LIMIT n' with 'FETCH FIRST n ROWS ONLY' when using ibm_db

### DIFF
--- a/lib/arel/visitors.rb
+++ b/lib/arel/visitors.rb
@@ -10,6 +10,7 @@ require 'arel/visitors/join_sql'
 require 'arel/visitors/where_sql'
 require 'arel/visitors/order_clauses'
 require 'arel/visitors/dot'
+require 'arel/visitors/ibm_db'
 
 module Arel
   module Visitors
@@ -22,6 +23,7 @@ module Arel
       'oracle_enhanced' => Arel::Visitors::Oracle,
       'sqlite'          => Arel::Visitors::SQLite,
       'sqlite3'         => Arel::Visitors::SQLite,
+      'ibm_db'          => Arel::Visitors::IBM_DB,
     }
 
     ENGINE_VISITORS = Hash.new do |hash, engine|

--- a/lib/arel/visitors/ibm_db.rb
+++ b/lib/arel/visitors/ibm_db.rb
@@ -1,0 +1,12 @@
+module Arel
+  module Visitors
+    class IBM_DB < Arel::Visitors::ToSql
+      private
+
+      def visit_Arel_Nodes_Limit o
+        "FETCH FIRST #{visit o.expr} ROWS ONLY"
+      end
+
+    end
+  end
+end

--- a/test/visitors/test_ibm_db.rb
+++ b/test/visitors/test_ibm_db.rb
@@ -1,0 +1,27 @@
+require 'helper'
+
+module Arel
+  module Visitors
+    describe 'the ibm_db visitor' do
+      before do
+        @visitor = IBM_DB.new Table.engine
+      end
+
+      it 'uses FETCH FIRST n ROWS to limit results' do
+        stmt = Nodes::SelectStatement.new
+        stmt.limit = Nodes::Limit.new(1)
+        sql = @visitor.accept(stmt)
+        sql.must_be_like "SELECT FETCH FIRST 1 ROWS ONLY"
+      end
+
+      it 'uses FETCH FIRST n ROWS in updates with a limit' do
+        stmt = Nodes::UpdateStatement.new
+        stmt.limit = Nodes::Limit.new(1)
+        stmt.key = 'id'
+        sql = @visitor.accept(stmt)
+        sql.must_be_like "UPDATE NULL WHERE 'id' IN (SELECT 'id' FETCH FIRST 1 ROWS ONLY)"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Like MSSQL, IBM DB2 uses a different syntax to limit the number of rows returned. This patch makes it work.
