### PR TITLE
Stop calling to_s on aliases, require them to be strings already.

### DIFF
--- a/lib/arel/alias_predication.rb
+++ b/lib/arel/alias_predication.rb
@@ -1,7 +1,7 @@
 module Arel
   module AliasPredication
     def as other
-      Nodes::As.new self, Nodes::SqlLiteral.new(other.to_s)
+      Nodes::As.new self, Nodes::SqlLiteral.new(other)
     end
   end
 end

--- a/lib/arel/nodes/function.rb
+++ b/lib/arel/nodes/function.rb
@@ -6,12 +6,12 @@ module Arel
 
       def initialize expr, aliaz = nil
         @expressions = expr
-        @alias       = aliaz && SqlLiteral.new(aliaz.to_s)
+        @alias       = aliaz && SqlLiteral.new(aliaz)
         @distinct    = false
       end
 
       def as aliaz
-        self.alias = SqlLiteral.new(aliaz.to_s)
+        self.alias = SqlLiteral.new(aliaz)
         self
       end
     end

--- a/test/visitors/test_depth_first.rb
+++ b/test/visitors/test_depth_first.rb
@@ -50,14 +50,14 @@ module Arel
         Arel::Nodes::Sum,
       ].each do |klass|
         define_method("test_#{klass.name.gsub('::', '_')}") do
-          func = klass.new(:a, :b)
+          func = klass.new(:a, "b")
           @visitor.accept func
           assert_equal [:a, "b", false, func], @collector.calls
         end
       end
 
       def test_named_function
-        func = Arel::Nodes::NamedFunction.new(:a, :b, :c)
+        func = Arel::Nodes::NamedFunction.new(:a, :b, "c")
         @visitor.accept func
         assert_equal [:a, :b, false, "c", func], @collector.calls
       end
@@ -69,7 +69,7 @@ module Arel
       end
 
       def test_count
-        count = Nodes::Count.new :a, :b, :c
+        count = Nodes::Count.new :a, :b, "c"
         @visitor.accept count
         assert_equal [:a, "c", :b, count], @collector.calls
       end

--- a/test/visitors/test_dot.rb
+++ b/test/visitors/test_dot.rb
@@ -16,7 +16,7 @@ module Arel
         Nodes::Avg,
       ].each do |klass|
         define_method("test_#{klass.name.gsub('::', '_')}") do
-          op = klass.new(:a, :z)
+          op = klass.new(:a, "z")
           @visitor.accept op
         end
       end


### PR DESCRIPTION
As discussed. I ran the AR test suite against this version of ARel, and was pleasantly surprised to see no failures -- looks like any calls to #as are already being done with strings -- or we don't have test coverage on those calls -- hopefully the former. :)
