### PR TITLE
Include Arel::Predicates to Arel::Nodes::Function

### DIFF
--- a/lib/arel/nodes/function.rb
+++ b/lib/arel/nodes/function.rb
@@ -2,6 +2,7 @@ module Arel
   module Nodes
     class Function < Arel::Nodes::Node
       include Arel::Expression
+      include Arel::Predications
       attr_accessor :expressions, :alias, :distinct
 
       def initialize expr, aliaz = nil

--- a/lib/arel/nodes/named_function.rb
+++ b/lib/arel/nodes/named_function.rb
@@ -3,8 +3,6 @@ module Arel
     class NamedFunction < Arel::Nodes::Function
       attr_accessor :name
 
-      include Arel::Predications
-
       def initialize name, expr, aliaz = nil
         super(expr, aliaz)
         @name = name

--- a/test/nodes/test_count.rb
+++ b/test/nodes/test_count.rb
@@ -15,4 +15,13 @@ describe Arel::Nodes::Count do
       }
     end
   end
+
+  describe "eq" do
+    it "should compare the count" do
+      table = Arel::Table.new :users
+      table[:id].count.eq(2).to_sql.must_be_like %{
+        COUNT("users"."id") = 2
+      }
+    end
+  end
 end


### PR DESCRIPTION
This lets you do `table[:id].count.eq(2)`.
Useful for when you `GROUP BY` and want to add `HAVING COUNT("things"."id") = 2`.
