### PR TITLE
Better support for MSSQL

### DIFF
--- a/lib/arel/visitors/mssql.rb
+++ b/lib/arel/visitors/mssql.rb
@@ -24,7 +24,6 @@ module Arel
             x.projections = [row_num_literal(core_order_by)]
             is_select_count = true
           else
-            guard_against_select_constant! x
             x.projections << row_num_literal(core_order_by)
           end
 
@@ -63,21 +62,12 @@ module Arel
         x.projections.length == 1 && Arel::Nodes::Count === x.projections.first
       end
 
-      def guard_against_select_constant! x
-        # guard against .select(1) (i.e. validate_uniqueness uses it to minimize qry result set)
-        # todo it won't work for .select('a'), which is probably ok. 'coz of workaround: .select("'a' as a")
-        x.projections.map! do |p|
-          p.kind_of?(Fixnum) ? Nodes::SqlLiteral.new("#{p} as _fld_#{p}") : p
-        end
-      end
-
       # fixme raise exception of there is no pk?
       # fixme!! Table.primary_key will be depricated. What is the replacement??
       def find_left_table_pk o
         return visit o.primary_key if o.instance_of? Arel::Table
         find_left_table_pk o.left if o.kind_of? Arel::Nodes::Join
       end
-
     end
   end
 end

--- a/test/visitors/test_mssql.rb
+++ b/test/visitors/test_mssql.rb
@@ -53,14 +53,6 @@ module Arel
         sql.must_be_like "SELECT _t.* FROM (SELECT ROW_NUMBER() OVER (ORDER BY ) as _row_num) as _t WHERE _row_num >= 21"
       end
 
-      it 'should guard FixNums' do
-        stmt = Nodes::SelectStatement.new
-        stmt.limit = Nodes::Limit.new(10)
-        stmt.cores.first.projections << 1
-        sql = @visitor.accept(stmt)
-        sql.must_be_like "SELECT _t.* FROM (SELECT 1 as _fld_1, ROW_NUMBER() OVER (ORDER BY ) as _row_num) as _t WHERE _row_num BETWEEN 1 AND 10"
-      end
-
       it 'should generate subquery for .count' do
         stmt = Nodes::SelectStatement.new
         stmt.limit = Nodes::Limit.new(10)


### PR DESCRIPTION
This adds support for .limit() and .offset() for MSSQL. I have been using this code with JRuby and JDBC adapter in our dev. It works fine with Rails 3.0.7.
