### PR TITLE
Fix for oracle treating empty string as null 

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -54,6 +54,20 @@ module Arel
         super
       end
 
+      def visit_Arel_Nodes_Equality o
+        condition_for o, 'IS', '='
+      end
+
+      def visit_Arel_Nodes_NotEqual o
+        condition_for o, 'IS NOT', '!='
+      end
+
+      def condition_for o, null_condition, value_condition
+        right = o.right
+        blank = right && right.empty? #.blank? in RAILS
+        "#{visit o.left} #{blank ? "#{null_condition} NULL" : "#{value_condition} #{visit right}"}"
+      end
+
       def visit_Arel_Nodes_Limit o
       end
 

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -55,6 +55,24 @@ module Arel
         }
       end
 
+      describe 'Equality' do
+        it 'empty string should be IS NULL check' do
+          test = Table.new(:users)[:name].eq ''
+          @visitor.accept(test).must_be_like %{
+            "users"."name" IS NULL
+          }
+        end
+      end
+      
+      describe 'InEquality' do
+        it 'empty string should be IS NOT NULL check' do
+          test = Table.new(:users)[:name].not_eq ''
+          @visitor.accept(test).must_be_like %{
+            "users"."name" IS NOT NULL
+          }
+        end
+      end
+
       describe 'Nodes::SelectStatement' do
         describe 'limit' do
           it 'adds a rownum clause' do


### PR DESCRIPTION
oracle converts/treats any empty string inserted into a varchar column as null.

i.e.
if you create a new record, the initial in memory object will have the empty string as expected, but when reloaded it will be null

```
a = A.create(:b => '')   # [A :b => '']
a.reload                       # [A :b => nil]
```

so if someone expects to query that record as an empty string, arel needs to handle it as a NULL check to find that record

```
found = A.where(:b => '')   # [A :b => nil]
```
