### PR TITLE
Support locking in Oracle

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -3,6 +3,10 @@ module Arel
     class Oracle < Arel::Visitors::ToSql
       private
 
+      def visit_Arel_Nodes_Lock o
+        visit o.expr
+      end
+
       def visit_Arel_Nodes_SelectStatement o
         o = order_hacks(o)
 

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -143,6 +143,13 @@ module Arel
           ( SELECT * FROM users WHERE age > 10 MINUS SELECT * FROM users WHERE age > 20 )
         }
       end
+
+      describe 'locking' do
+        it 'defaults to FOR UPDATE when locking' do
+          node = Nodes::Lock.new(Arel.sql('FOR UPDATE'))
+          @visitor.accept(node).must_be_like "FOR UPDATE"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I have added locking for Oracle, but as I understand then locking in arel is disabled by default and only enabled for 2 databases - mysql and postgresql. Should'nt it be enabled by default and disabled only for sqlite?
