### PR TITLE
Support locking by default and disable it only for SQLite

### DIFF
--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -28,10 +28,6 @@ module Arel
         "BINARY #{visit o.expr}"
       end
 
-      def visit_Arel_Nodes_Lock o
-        visit o.expr
-      end
-
       ###
       # :'(
       # http://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -3,10 +3,6 @@ module Arel
     class Oracle < Arel::Visitors::ToSql
       private
 
-      def visit_Arel_Nodes_Lock o
-        visit o.expr
-      end
-
       def visit_Arel_Nodes_SelectStatement o
         o = order_hacks(o)
 

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -2,9 +2,6 @@ module Arel
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql
       private
-      def visit_Arel_Nodes_Lock o
-        visit o.expr
-      end
 
       def visit_Arel_Nodes_Matches o
         "#{visit o.left} ILIKE #{visit o.right}"

--- a/lib/arel/visitors/sqlite.rb
+++ b/lib/arel/visitors/sqlite.rb
@@ -2,6 +2,11 @@ module Arel
   module Visitors
     class SQLite < Arel::Visitors::ToSql
       private
+
+      # Locks are not supported in SQLite
+      def visit_Arel_Nodes_Lock o
+      end
+
       def visit_Arel_Nodes_SelectStatement o
         o.limit = Arel::Nodes::Limit.new(-1) if o.offset && !o.limit
         super

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -200,9 +200,8 @@ key on UpdateManager using UpdateManager#key=
         ""
       end
 
-      # FIXME: this does nothing on SQLLite3, but should do things on other
-      # databases.
       def visit_Arel_Nodes_Lock o
+        visit o.expr
       end
 
       def visit_Arel_Nodes_Grouping o

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -454,7 +454,7 @@ module Arel
       it 'adds a lock node' do
         table   = Table.new :users
         mgr = table.from table
-        mgr.lock.to_sql.must_be_like %{ SELECT FROM "users" }
+        mgr.lock.to_sql.must_be_like %{ SELECT FROM "users" FOR UPDATE }
       end
     end
 

--- a/test/visitors/test_sqlite.rb
+++ b/test/visitors/test_sqlite.rb
@@ -13,6 +13,11 @@ module Arel
         sql = @visitor.accept(stmt)
         sql.must_be_like "SELECT LIMIT -1 OFFSET 1"
       end
+
+      it 'does not support locking' do
+        node = Nodes::Lock.new(Arel.sql('FOR UPDATE'))
+        @visitor.accept(node).must_be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Changed the logic so that locking is enabled by default in all databases except SQLite (based on #77).
