### PR TITLE
Proposed fix for issue 79 - https://github.com/rails/arel/issues/79

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -51,7 +51,7 @@ module Arel
       if $VERBOSE
         warn "(#{caller.first}) where_clauses is deprecated and will be removed in arel 3.0.0 with no replacement"
       end
-      to_sql = Visitors::ToSql.new @engine
+      to_sql = Visitors::ToSql.new @engine.connection_pool
       @ctx.wheres.map { |c| to_sql.accept c }
     end
 


### PR DESCRIPTION
Proposed fix for issue 79 - https://github.com/rails/arel/issues/79 - Pass the connection_pool to the ToSql initializer, rather than the engine itself.
