### PR TITLE
BUGFIX: uninitialized constant Arel::Nodes::Visitors::DepthFirst

### DIFF
--- a/lib/arel/nodes/node.rb
+++ b/lib/arel/nodes/node.rb
@@ -39,7 +39,7 @@ module Arel
       def each &block
         return enum_for(:each) unless block_given?
 
-        Visitors::DepthFirst.new(block).accept self
+        ::Arel::Visitors::DepthFirst.new(block).accept self
       end
     end
   end


### PR DESCRIPTION
while using activerecord-sqlserver-adapter 3.1.5 with Rails 3.1 with Arel 2.2.1 we encountered the error
  uninitialized constant Arel::Nodes::Visitors::DepthFirst
apparently Arel was trying to call a relative namespace with
  Visitors::DepthFirst.new(block).accept self
we fixed this by making it call an absolute namespace with
  ::Arel::Visitors::DepthFirst.new(block).accept self
