### PR TITLE
Delete should respect 'limit'

### DIFF
--- a/lib/arel/crud.rb
+++ b/lib/arel/crud.rb
@@ -54,6 +54,7 @@ switch to `compile_insert`
 
     def compile_delete
       dm = DeleteManager.new @engine
+      dm.take @ast.limit.expr if @ast.limit
       dm.wheres = @ctx.wheres
       dm.from @ctx.froms
       dm

--- a/lib/arel/delete_manager.rb
+++ b/lib/arel/delete_manager.rb
@@ -11,6 +11,11 @@ module Arel
       self
     end
 
+    def take limit
+      @ast.limit = Nodes::Limit.new(limit) if limit
+      self
+    end
+
     def wheres= list
       @ast.wheres = list
     end

--- a/lib/arel/nodes/delete_statement.rb
+++ b/lib/arel/nodes/delete_statement.rb
@@ -1,6 +1,8 @@
 module Arel
   module Nodes
     class DeleteStatement < Arel::Nodes::Binary
+      attr_accessor :limit
+      
       alias :relation :left
       alias :relation= :left=
       alias :wheres :right
@@ -8,6 +10,7 @@ module Arel
 
       def initialize relation = nil, wheres = []
         super
+        @limit = nil
       end
 
       def initialize_copy other

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -23,7 +23,8 @@ module Arel
       def visit_Arel_Nodes_DeleteStatement o
         [
           "DELETE FROM #{visit o.relation}",
-          ("WHERE #{o.wheres.map { |x| visit x }.join ' AND '}" unless o.wheres.empty?)
+          ("WHERE #{o.wheres.map { |x| visit x }.join ' AND '}" unless o.wheres.empty?),
+          (visit(o.limit) if o.limit)
         ].compact.join ' '
       end
 

--- a/test/test_delete_manager.rb
+++ b/test/test_delete_manager.rb
@@ -8,6 +8,14 @@ module Arel
       end
     end
 
+    it 'handles limit properly' do
+      table = Table.new(:users)
+      dm = Arel::DeleteManager.new Table.engine
+      dm.take 10
+      dm.from table
+      assert_match(/LIMIT 10/, dm.to_sql)
+    end
+
     describe 'from' do
       it 'uses from' do
         table = Table.new(:users)


### PR DESCRIPTION
I was surprised to find limit(...).delete_all didn't work so I added the following limit recognition to the rails arel libs.

I'm sure there was a reason for omitting 'limit' from the delete statements, but just in case it should be there, here's a patch that adds the functionality.