### PR TITLE
Patch Informix Visitor so that it includes joins

### DIFF
--- a/lib/arel/visitors/informix.rb
+++ b/lib/arel/visitors/informix.rb
@@ -15,7 +15,7 @@ module Arel
       def visit_Arel_Nodes_SelectCore o
         [
           "#{o.projections.map { |x| visit x }.join ', '}",
-          ("FROM #{visit o.froms}" if o.froms),
+          ("FROM #{visit(o.source)}" if o.source && !o.source.empty?),
           ("WHERE #{o.wheres.map { |x| visit x }.join ' AND ' }" unless o.wheres.empty?),
           ("GROUP BY #{o.groups.map { |x| visit x }.join ', ' }" unless o.groups.empty?),
           (visit(o.having) if o.having),

--- a/test/visitors/test_informix.rb
+++ b/test/visitors/test_informix.rb
@@ -37,6 +37,16 @@ module Arel
         sql.must_be_like "SELECT SKIP 1 LIMIT 1"
       end
 
+      it 'uses INNER JOIN to perform joins' do
+        core = Nodes::SelectCore.new
+        table = Table.new(:posts)
+        core.source = Nodes::JoinSource.new(table, [table.create_join(Table.new(:comments))])
+
+        stmt = Nodes::SelectStatement.new([core])
+        sql = @visitor.accept(stmt)
+        sql.must_be_like 'SELECT FROM "posts" INNER JOIN "comments"'
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fixes issue #105, in which the Informix Visitor ignores table joins. Includes a [previously failing] test. 
