### PR TITLE
Adds visit_Arel_Nodes_InfixOperation to Arel::Visitors::DepthFirst

### DIFF
--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -70,6 +70,7 @@ module Arel
       alias :visit_Arel_Nodes_GreaterThan        :binary
       alias :visit_Arel_Nodes_GreaterThanOrEqual :binary
       alias :visit_Arel_Nodes_In                 :binary
+      alias :visit_Arel_Nodes_InfixOperation     :binary
       alias :visit_Arel_Nodes_JoinSource         :binary
       alias :visit_Arel_Nodes_InnerJoin          :binary
       alias :visit_Arel_Nodes_LessThan           :binary

--- a/test/visitors/test_depth_first.rb
+++ b/test/visitors/test_depth_first.rb
@@ -114,6 +114,12 @@ module Arel
         end
       end
 
+      def test_Arel_Nodes_InfixOperation
+        binary = Arel::Nodes::InfixOperation.new(:o, :a, :b)
+        @visitor.accept binary
+        assert_equal [:a, :b, binary], @collector.calls
+      end
+
       # N-ary
       [
         Arel::Nodes::And,


### PR DESCRIPTION
This pull requests adds an alias for `visit_Arel_Nodes_InfixOperation` to `Arel::Visitors::DepthFirst`.

Without this alias there will be a `NoMethodError` which will mess up the `Arel::Visitors::Visitor::DISPATCH` in some situations (like `Model.some_scope.count` in ActiveRecord). As a result subsequent tree traversals involving `Arel::Nodes::InfixOperation` will fail, too.
