### PR TITLE
Remove deprecated Relation module

### DIFF
--- a/lib/arel.rb
+++ b/lib/arel.rb
@@ -12,8 +12,6 @@ require 'arel/attributes'
 require 'arel/compatibility/wheres'
 
 #### these are deprecated
-# The Arel::Relation constant is referenced in Rails
-require 'arel/relation'
 require 'arel/expression'
 ####
 

--- a/lib/arel/relation.rb
+++ b/lib/arel/relation.rb
@@ -1,6 +1,0 @@
-module Arel
-  ###
-  # This is deprecated.  Fix rails, then remove this.
-  module Relation
-  end
-end

--- a/lib/arel/tree_manager.rb
+++ b/lib/arel/tree_manager.rb
@@ -1,7 +1,5 @@
 module Arel
   class TreeManager
-    # FIXME: Remove this.
-    include Arel::Relation
     include Arel::FactoryMethods
 
     attr_reader :ast, :engine


### PR DESCRIPTION
Deprecated Relation module is not needed anymore if reference is removed from Rails.

related PR in rails repo: https://github.com/rails/rails/pull/5610
