### PR TITLE
Update travis.yml to use the right Rubinius versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 script: "rake test"
 rvm:
   - 1.8.7
-  - rbx  
-  - rbx-2.0
+  - rbx-18mode
+  - rbx-19mode
   - jruby
   - 1.9.2
   - 1.9.3


### PR DESCRIPTION
It looks like "rbx" and "rbx-2.0" are no longer supported on Travis, they now support "rbx-18mode" and "rbx-19mode".

http://about.travis-ci.org/docs/user/ci-environment/

rbx-19 is incidentally failing, due to something upstream with Hoe.
