### PR TITLE
Remove some test warnings

### DIFF
--- a/test/test_insert_manager.rb
+++ b/test/test_insert_manager.rb
@@ -10,7 +10,6 @@ module Arel
 
     describe 'insert' do
       it 'can create a Values node' do
-        table   = Table.new(:users)
         manager = Arel::InsertManager.new Table.engine
         values  = manager.create_values %w{ a b }, %w{ c d }
 
@@ -20,7 +19,6 @@ module Arel
       end
 
       it 'allows sql literals' do
-        table          = Table.new(:users)
         manager        = Arel::InsertManager.new Table.engine
         manager.values = manager.create_values [Arel.sql('*')], %w{ a }
         manager.to_sql.must_be_like %{

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -672,7 +672,6 @@ module Arel
       end
 
       it 'returns string join sql' do
-        table   = Table.new :users
         manager = Arel::SelectManager.new Table.engine
         manager.from Nodes::StringJoin.new('hello')
         manager.join_sql.must_be_like %{ 'hello' }
@@ -1140,7 +1139,6 @@ module Arel
 
     describe 'source' do
       it 'returns the join source of the select core' do
-        table   = Table.new :users
         manager = Arel::SelectManager.new Table.engine
         manager.source.must_equal manager.ast.cores.last.source
       end
@@ -1148,7 +1146,6 @@ module Arel
 
     describe 'distinct' do
       it 'sets the quantifier' do
-        table   = Table.new :users
         manager = Arel::SelectManager.new Table.engine
 
         manager.distinct


### PR DESCRIPTION
These `table` variables are giving warnings and doesn't seem to be required for such tests.

I'm also getting this warning when running tests:

```
arel/lib/arel/nodes/window.rb:21: warning: instance variable @frame not initialized
```

The warning is in this method:

``` ruby
def frame(expr)
  raise ArgumentError, "Window frame cannot be set more than once" if @frame
  @framing = expr
end
```

Where I believe the `@frame` variable should actually be `framing`, but this gives me 2 failing tests in `test_select_manager.rb`. I'll try to take a look into this later, but any directions are welcome. Thanks.
