### PR TITLE
remove "instance variable not initialized" warnings 

### DIFF
--- a/lib/arel/nodes/window.rb
+++ b/lib/arel/nodes/window.rb
@@ -17,7 +17,7 @@ module Arel
       end
 
       def frame(expr)
-        raise ArgumentError, "Window frame cannot be set more than once" if @frame
+        raise ArgumentError, "Window frame cannot be set more than once" if defined? @frame
         @framing = expr
       end
 


### PR DESCRIPTION
I was receiving a lot of warnings about this when running the tests: `/lib/arel/nodes/window.rb:20: warning: instance variable @frame not initialized`

This removes them.
