### PR TITLE
Fix limit with GROUP BY in Oracle

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -8,7 +8,7 @@ module Arel
 
         # if need to select first records without ORDER BY and GROUP BY and without DISTINCT
         # then can use simple ROWNUM in WHERE clause
-        if o.limit && o.orders.empty? && !o.offset && o.cores.first.projections.first !~ /^DISTINCT /
+        if o.limit && o.orders.empty? && o.cores.first.groups.empty? && !o.offset && o.cores.first.projections.first !~ /^DISTINCT /
           o.cores.last.wheres.push Nodes::LessThanOrEqual.new(
             Nodes::SqlLiteral.new('ROWNUM'), o.limit.expr
           )

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -83,6 +83,16 @@ module Arel
             }
           end
 
+          it 'creates a subquery when there is group by' do
+            stmt = Nodes::SelectStatement.new
+            stmt.cores.first.groups << Nodes::SqlLiteral.new('foo')
+            stmt.limit = Nodes::Limit.new(10)
+            sql = @visitor.accept stmt
+            sql.must_be_like %{
+              SELECT * FROM (SELECT GROUP BY foo) WHERE ROWNUM <= 10
+            }
+          end
+
           it 'creates a subquery when there is DISTINCT' do
             stmt = Nodes::SelectStatement.new
             stmt.cores.first.projections << Nodes::SqlLiteral.new('DISTINCT id')


### PR DESCRIPTION
I think this fix is fairly straight-forward. There's also a test case here demonstrating the problem.

References #128
