### PR TITLE
to_sql: add support for emitting SQL subqueries

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -254,6 +254,10 @@ key on UpdateManager using UpdateManager#key=
         "(#{visit o.expr})"
       end
 
+      def visit_Arel_SelectManager o
+        "(#{o.to_sql.rstrip})"
+      end
+
       def visit_Arel_Nodes_Ascending o
         "#{visit o.expr} ASC"
       end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -126,6 +126,11 @@ module Arel
         @visitor.accept(nil).must_be_like "NULL"
       end
 
+      it "should visit_Arel_SelectManager, which is a subquery" do
+        mgr = Table.new(:foo).project(:bar)
+        @visitor.accept(mgr).must_be_like '(SELECT bar FROM "foo")'
+      end
+
       it "should visit_Arel_Nodes_And" do
         node = Nodes::And.new [@attr.eq(10), @attr.eq(11)]
         @visitor.accept(node).must_be_like %{


### PR DESCRIPTION
Added support for running `#to_sql()` on an Arel query tree that contains nested subqueries (Arel::SelectManager), which themselves may contain nested subqueries, _ad infinitum_. :cake:
