### PR TITLE
[RFC] Arel::SelectManager support for DepthFirst visitor

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -14,6 +14,10 @@ module Arel
       @ctx = @ast.cores.last
     end
 
+    def statement
+      @ast
+    end
+
     def limit
       @ast.limit && @ast.limit.expr
     end

--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -150,6 +150,10 @@ module Arel
         visit o.offset
       end
 
+      def visit_Arel_SelectManager o
+        visit o.statement
+      end
+
       def visit_Arel_Nodes_UpdateStatement o
         visit o.relation
         visit o.values

--- a/test/visitors/test_depth_first.rb
+++ b/test/visitors/test_depth_first.rb
@@ -218,6 +218,13 @@ module Arel
           ss], @collector.calls
       end
 
+      def test_select_manager
+        sm = Table.new(:foo).project(:bar)
+        def sm.statement; :a; end
+        @visitor.accept sm
+        assert_equal [:a, sm], @collector.calls
+      end
+
       def test_insert_statement
         stmt = Nodes::InsertStatement.new
         stmt.relation = :a


### PR DESCRIPTION
Hello,

In this commit, I have added a `SelectManager#statement()` method to expose the underlying tree for `DepthFirst` visitor to traverse.

For API consistency, should I do the same for the other `*Manager` classes to add support for traversing them in the `DepthFirst` visitor?

Thanks for your consideration.
