### PR TITLE
Support for MySQL DELETE USING

### DIFF
--- a/lib/arel/crud.rb
+++ b/lib/arel/crud.rb
@@ -55,6 +55,7 @@ switch to `compile_insert`
     def compile_delete
       dm = DeleteManager.new @engine
       dm.wheres = @ctx.wheres
+      dm.source = @ctx.source
       dm.from @ctx.froms
       dm
     end

--- a/lib/arel/delete_manager.rb
+++ b/lib/arel/delete_manager.rb
@@ -11,6 +11,10 @@ module Arel
       self
     end
 
+    def source= source
+      @ast.source = source
+    end
+
     def wheres= list
       @ast.wheres = list
     end

--- a/lib/arel/nodes/delete_statement.rb
+++ b/lib/arel/nodes/delete_statement.rb
@@ -1,19 +1,33 @@
 module Arel
   module Nodes
-    class DeleteStatement < Arel::Nodes::Binary
-      alias :relation :left
-      alias :relation= :left=
-      alias :wheres :right
-      alias :wheres= :right=
+    class DeleteStatement < Arel::Nodes::Node
+      attr_accessor :relation, :source, :wheres
 
-      def initialize relation = nil, wheres = []
-        super
+      def initialize
+        @relation = nil
+        @source   = nil
+        @wheres   = []
       end
 
       def initialize_copy other
         super
-        @right = @right.clone
+        @relation = @relation.clone if @relation
+        @source   = @source.clone   if @source
+        @wheres   = @wheres.clone   if @wheres
       end
+
+      def hash
+        [@relation, @source, @wheres].hash
+      end
+
+      def eql? other
+        self.class == other.class &&
+          self.relation == other.relation &&
+          self.source   == other.source   &&
+          self.wheres   == other.wheres
+      end
+      alias :== :eql?
+
     end
   end
 end

--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -64,7 +64,6 @@ module Arel
       alias :visit_Arel_Nodes_As                 :binary
       alias :visit_Arel_Nodes_Assignment         :binary
       alias :visit_Arel_Nodes_Between            :binary
-      alias :visit_Arel_Nodes_DeleteStatement    :binary
       alias :visit_Arel_Nodes_DoesNotMatch       :binary
       alias :visit_Arel_Nodes_Equality           :binary
       alias :visit_Arel_Nodes_GreaterThan        :binary
@@ -156,6 +155,12 @@ module Arel
         visit o.wheres
         visit o.orders
         visit o.limit
+      end
+
+      def visit_Arel_Nodes_DeleteStatement o
+        visit o.relation
+        visit o.source
+        visit o.wheres
       end
 
       def visit_Array o

--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -58,6 +58,7 @@ module Arel
 
       def visit_Arel_Nodes_DeleteStatement o
         visit_edge o, "relation"
+        visit_edge o, "source"
         visit_edge o, "wheres"
       end
 

--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -51,6 +51,14 @@ module Arel
         ].compact.join ' '
       end
 
+      def visit_Arel_Nodes_DeleteStatement o
+        [
+          "DELETE FROM #{visit o.relation}",
+          ("USING #{visit(o.source)}" if o.source && o.source.right && !o.source.right.empty?),
+          ("WHERE #{o.wheres.map { |x| visit x }.join ' AND '}" unless o.wheres.empty?)
+        ].compact.join ' '
+      end
+
     end
   end
 end

--- a/test/nodes/test_delete_statement.rb
+++ b/test/nodes/test_delete_statement.rb
@@ -10,14 +10,25 @@ describe Arel::Nodes::DeleteStatement do
       dolly.wheres.must_equal statement.wheres
       dolly.wheres.wont_be_same_as statement.wheres
     end
+
+    it "clones source" do
+      statement = Arel::Nodes::DeleteStatement.new
+      statement.source = %w[a b c]
+
+      dolly = statement.clone
+      dolly.source.must_equal statement.source
+      dolly.source.wont_be_same_as statement.source
+    end
   end
 
   describe 'equality' do
     it 'is equal with equal ivars' do
       statement1 = Arel::Nodes::DeleteStatement.new
       statement1.wheres = %w[a b c]
+      statement1.source = %w[d e f]
       statement2 = Arel::Nodes::DeleteStatement.new
       statement2.wheres = %w[a b c]
+      statement2.source = %w[d e f]
       array = [statement1, statement2]
       assert_equal 1, array.uniq.size
     end
@@ -25,8 +36,10 @@ describe Arel::Nodes::DeleteStatement do
     it 'is not equal with different ivars' do
       statement1 = Arel::Nodes::DeleteStatement.new
       statement1.wheres = %w[a b c]
+      statement1.source = %w[d e f]
       statement2 = Arel::Nodes::DeleteStatement.new
       statement2.wheres = %w[1 2 3]
+      statement2.source = %w[4 5 6]
       array = [statement1, statement2]
       assert_equal 2, array.uniq.size
     end

--- a/test/test_delete_manager.rb
+++ b/test/test_delete_manager.rb
@@ -38,5 +38,17 @@ module Arel
         dm.where(table[:id].eq(10)).must_equal dm
       end
     end
+
+    describe 'source' do
+      it 'ignores source' do
+        table = Table.new(:users)
+        source = Arel::Nodes::JoinSource.new table
+        source.right << Arel::Nodes::StringJoin.new('foo')
+        dm = Arel::DeleteManager.new Table.engine
+        dm.from table
+        dm.source = source
+        dm.to_sql.must_be_like %{ DELETE FROM "users" }
+      end
+    end
   end
 end

--- a/test/visitors/test_depth_first.rb
+++ b/test/visitors/test_depth_first.rb
@@ -104,7 +104,6 @@ module Arel
         Arel::Nodes::TableAlias,
         Arel::Nodes::Values,
         Arel::Nodes::As,
-        Arel::Nodes::DeleteStatement,
         Arel::Nodes::JoinSource,
       ].each do |klass|
         define_method("test_#{klass.name.gsub('::', '_')}") do
@@ -226,6 +225,16 @@ module Arel
 
         @visitor.accept stmt
         assert_equal [:a, :b, stmt.columns, :c, stmt], @collector.calls
+      end
+
+      def test_delete_statement
+        stmt = Arel::Nodes::DeleteStatement.new
+        stmt.relation = :a
+        stmt.source   = :b
+        stmt.wheres   = :c
+
+        @visitor.accept stmt
+        assert_equal [:a, :b, :c, stmt], @collector.calls
       end
 
       def test_node

--- a/test/visitors/test_dot.rb
+++ b/test/visitors/test_dot.rb
@@ -63,7 +63,6 @@ module Arel
         Arel::Nodes::TableAlias,
         Arel::Nodes::Values,
         Arel::Nodes::As,
-        Arel::Nodes::DeleteStatement,
         Arel::Nodes::JoinSource,
       ].each do |klass|
         define_method("test_#{klass.name.gsub('::', '_')}") do

--- a/test/visitors/test_mysql.rb
+++ b/test/visitors/test_mysql.rb
@@ -50,6 +50,26 @@ module Arel
           @visitor.accept(node).must_be_like "LOCK IN SHARE MODE"
         end
       end
+
+      describe 'deleting' do
+        it 'adds join sources if present to USING clause' do
+          stmt = Nodes::DeleteStatement.new
+          stmt.relation = Table.new(:users)
+          stmt.source = Nodes::JoinSource.new stmt.relation
+          stmt.source.right << Nodes::StringJoin.new('foo');
+          sql = @visitor.accept(stmt)
+          sql.must_be_like %{ DELETE FROM "users" USING "users" 'foo' }
+        end
+
+        it 'does not include USING clause without join sources' do
+          stmt = Nodes::DeleteStatement.new
+          stmt.relation = Table.new(:users)
+          stmt.source = Nodes::JoinSource.new stmt.relation
+          sql = @visitor.accept(stmt)
+          sql.must_be_like %{ DELETE FROM "users" }
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Enables delete_all on has_many :through associations, e.g.

  chapter_one.paragraphs.where(:editor_id => 1).delete_all

  DELETE FROM `paragraphs` USING `paragraphs` INNER JOIN `sections` ON `paragraphs`.`section_id` = `sections`.`id` WHERE `sections`.`chapter_id` = 1 AND `paragraphs`.`editor_id` = 1

The current behavior is to omit the join such that the following error is raised:

  ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'sections.chapter_id' in 'where clause': DELETE FROM `paragraphs` WHERE `sections`.`chapter_id` = 1 AND `paragraphs`.`editor_id` = 1

This could also be implemented for postgresql visitor, although the non-standard USING clause would only contain the names of join tables and the join condition would be merged into the WHERE clause.
