### PR TITLE
Small change to oracle paging code to trigger stopkey optimization

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -26,7 +26,7 @@ module Arel
                 SELECT raw_sql_.*, rownum raw_rnum_
                 FROM (#{sql}) raw_sql_
               )
-              WHERE raw_rnum_ between #{offset.expr.to_i + 1 } and #{offset.expr.to_i + limit}
+              WHERE raw_rnum_ >= #{offset.expr.to_i + 1 } and rownum <= #{limit}
           eosql
         end
 

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -103,7 +103,7 @@ module Arel
                 SELECT raw_sql_.*, rownum raw_rnum_
                 FROM (SELECT) raw_sql_
               )
-              WHERE raw_rnum_ between 11 and 20
+              WHERE raw_rnum_ >= 11 and rownum <= 10
             }
           end
 


### PR DESCRIPTION
I previously added a comment on [issue 99](https://github.com/rails/arel/issues/99#issuecomment-12000009) about a quick tweak to the paging code and I didn't want it to go to waste. Changing the `raw_rnum_` predicate from:

`WHERE raw_rnum_ BETWEEN :low and :high` 

to: `WHERE raw_rnum_ >= :low and rownum <= :limit`

allows the optimizer to use the [count stopkey](http://decipherinfosys.wordpress.com/2007/08/09/paging-and-countstopkey-optimization/)  optimization and return the same results noticeably quicker. 

Here's the execution plan for my DB with the current code:
![no-stopkey](https://f.cloud.github.com/assets/144980/113364/45650ad4-6b4f-11e2-8304-32322f370626.png)

And with the changes:
![stopkey](https://f.cloud.github.com/assets/144980/113365/4b4cb582-6b4f-11e2-85cd-24ec91541cd1.png)

I've had this change running for almost a month in a few of my apps on 11G as well as some test projects on XE and everything seems cool, maybe someone else could give it a try and see if they get the same results?
