### PR TITLE
Test quoting integers when comparing a string column with integers.

### DIFF
--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -60,9 +60,13 @@ module FakeRecord
     end
 
     def quote thing, column = nil
-      if column && column.type == :integer
-        return 'NULL' if thing.nil?
-        return thing.to_i
+      if column && !thing.nil?
+        case column.type
+        when :integer
+          thing = thing.to_i
+        when :string
+          thing = thing.to_s
+        end
       end
 
       case thing
@@ -110,6 +114,10 @@ module FakeRecord
 
     def schema_cache
       connection
+    end
+
+    def quote thing, column = nil
+      connection.quote thing, column
     end
   end
 

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -119,6 +119,12 @@ module Arel
           sql.must_be_like %{ "users"."id" = 1 }
         end
 
+        it 'should use the column to quote integers' do
+          table = Table.new(:users)
+          sql = compile table[:name].eq(0)
+          sql.must_be_like %{ "users"."name" = '0' }
+        end
+
         it 'should handle nil' do
           sql = compile Nodes::Equality.new(@table[:name], nil)
           sql.must_be_like %{ "users"."name" IS NULL }
@@ -160,6 +166,12 @@ module Arel
         assert_match(/LIMIT 'omg'/, compile(sc))
       end
 
+      it "should quote LIMIT without column type coercion" do
+        table = Table.new(:users)
+        sc = table.where(table[:name].eq(0)).take(1).ast
+        assert_match(/WHERE "users"."name" = '0' LIMIT 1/, compile(sc))
+      end
+
       it "should visit_DateTime" do
         called_with = nil
         @conn.connection.extend(Module.new {
@@ -179,9 +191,9 @@ module Arel
       end
 
       it "should visit_Float" do
-        test = Table.new(:users)[:name].eq 2.14
+        test = Table.new(:products)[:price].eq 2.14
         sql = compile test
-        sql.must_be_like %{"users"."name" = 2.14}
+        sql.must_be_like %{"products"."price" = 2.14}
       end
 
       it "should visit_Not" do


### PR DESCRIPTION
Update: the original problem was fixed by commit 93d72131bcc24ccb5536bec672d2dac94f8de651, so now this just adds a regression test.
## Problem

An equality with a string column and integer like

``` sql
SELECT * FROM `users` WHERE `login_token` = 0 LIMIT 1;
```

will match any string that doesn't start with a digit in certain databases (including MySQL).  However, Arel will simply treat Fixnum and Bignum as literals, and not give the connection an opportunity to quote these values.

See [Potential Query Manipulation with Common Rails Practises](https://groups.google.com/forum/?hl=en&fromgroups=#!topic/rubyonrails-security/ZOdH5GH5jCU) for details on the potential security vulnerability.
## Solution

Arel should allow the connection to quote integers, but needs to provide the correct column type to avoid quoting integers like the argument to LIMIT.

Quoting the integer will avoid this potential security issue in a database independent way.  So the above query can be quoted as follows and only match a login_token with the exact string `'0'`.

``` sql
SELECT * FROM `users` WHERE `login_token` = '0' LIMIT 1;
```
