### PR TITLE
Support ESCAPE clause

### DIFF
--- a/lib/arel/nodes/binary.rb
+++ b/lib/arel/nodes/binary.rb
@@ -31,6 +31,7 @@ module Arel
       Assignment
       Between
       DoesNotMatch
+      Escape
       GreaterThan
       GreaterThanOrEqual
       Join

--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -67,6 +67,7 @@ module Arel
       alias :visit_Arel_Nodes_DeleteStatement    :binary
       alias :visit_Arel_Nodes_DoesNotMatch       :binary
       alias :visit_Arel_Nodes_Equality           :binary
+      alias :visit_Arel_Nodes_Escape             :binary
       alias :visit_Arel_Nodes_GreaterThan        :binary
       alias :visit_Arel_Nodes_GreaterThanOrEqual :binary
       alias :visit_Arel_Nodes_In                 :binary

--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -172,6 +172,7 @@ module Arel
       alias :visit_Arel_Nodes_Between            :binary
       alias :visit_Arel_Nodes_DoesNotMatch       :binary
       alias :visit_Arel_Nodes_Equality           :binary
+      alias :visit_Arel_Nodes_Escape             :binary
       alias :visit_Arel_Nodes_GreaterThan        :binary
       alias :visit_Arel_Nodes_GreaterThanOrEqual :binary
       alias :visit_Arel_Nodes_In                 :binary

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -439,6 +439,10 @@ key on UpdateManager using UpdateManager#key=
         "#{visit o.left} NOT LIKE #{visit o.right}"
       end
 
+      def visit_Arel_Nodes_Escape o
+        "#{visit o.left} ESCAPE #{visit o.right}"
+      end
+
       def visit_Arel_Nodes_JoinSource o
         [
           (visit(o.left) if o.left),

--- a/test/visitors/test_depth_first.rb
+++ b/test/visitors/test_depth_first.rb
@@ -92,6 +92,7 @@ module Arel
         Arel::Nodes::Between,
         Arel::Nodes::DoesNotMatch,
         Arel::Nodes::Equality,
+        Arel::Nodes::Escape,
         Arel::Nodes::GreaterThan,
         Arel::Nodes::GreaterThanOrEqual,
         Arel::Nodes::In,

--- a/test/visitors/test_dot.rb
+++ b/test/visitors/test_dot.rb
@@ -51,6 +51,7 @@ module Arel
         Arel::Nodes::Between,
         Arel::Nodes::DoesNotMatch,
         Arel::Nodes::Equality,
+        Arel::Nodes::Escape,
         Arel::Nodes::GreaterThan,
         Arel::Nodes::GreaterThanOrEqual,
         Arel::Nodes::In,


### PR DESCRIPTION
Added Arel::Nodes::Escape to escape special characters (% or _) in LIKE pattern.

``` ruby
# Usage
table = Arel::Table.new(:drinks)
query = table.project relation[:id]

escaped_pattern = Arel::Nodes::Escape.new('%100!% fruit juice', '!')
query.where relation[:name].matches(escaped_pattern)
query.to_sql
# => SELECT "drinks"."id" FROM "drinks" WHERE "drinks"."name" LIKE '%100!% fruit juice' ESCAPE '!'
```
