### PR TITLE
Informix versions < 10 use 'FIRST' keyword instead of 'LIMIT'

### DIFF
--- a/lib/arel/visitors/informix.rb
+++ b/lib/arel/visitors/informix.rb
@@ -41,7 +41,7 @@ module Arel
         visit o.expr, collector
       end
       def visit_Arel_Nodes_Limit o, collector
-        collector << "LIMIT "
+        collector << "FIRST "
         visit o.expr, collector
         collector << " "
       end

--- a/test/visitors/test_informix.rb
+++ b/test/visitors/test_informix.rb
@@ -11,21 +11,21 @@ module Arel
         @visitor.accept(node, Collectors::SQLString.new).value
       end
 
-      it 'uses LIMIT n to limit results' do
+      it 'uses FIRST n to limit results' do
         stmt = Nodes::SelectStatement.new
         stmt.limit = Nodes::Limit.new(1)
         sql = compile(stmt)
-        sql.must_be_like "SELECT LIMIT 1"
+        sql.must_be_like "SELECT FIRST 1"
       end
 
-      it 'uses LIMIT n in updates with a limit' do
+      it 'uses FIRST n in updates with a limit' do
         table = Table.new(:users)
         stmt = Nodes::UpdateStatement.new
         stmt.relation = table
         stmt.limit = Nodes::Limit.new(Nodes.build_quoted(1))
         stmt.key = table[:id]
         sql = compile(stmt)
-        sql.must_be_like "UPDATE \"users\" WHERE \"users\".\"id\" IN (SELECT LIMIT 1 \"users\".\"id\" FROM \"users\")"
+        sql.must_be_like "UPDATE \"users\" WHERE \"users\".\"id\" IN (SELECT FIRST 1 \"users\".\"id\" FROM \"users\")"
       end
 
       it 'uses SKIP n to jump results' do
@@ -35,12 +35,12 @@ module Arel
         sql.must_be_like "SELECT SKIP 10"
       end
 
-      it 'uses SKIP before LIMIT' do
+      it 'uses SKIP before FIRST' do
         stmt = Nodes::SelectStatement.new
         stmt.limit = Nodes::Limit.new(1)
         stmt.offset = Nodes::Offset.new(1)
         sql = compile(stmt)
-        sql.must_be_like "SELECT SKIP 1 LIMIT 1"
+        sql.must_be_like "SELECT SKIP 1 FIRST 1"
       end
 
       it 'uses INNER JOIN to perform joins' do


### PR DESCRIPTION
Informix Versions <= 9 use the 'FIRST' keyword to limit the number of records returned.
Version 10 introduced the 'LIMIT' keyword as an alias.
As far as I know, upper versions still support 'FIRST' (at least until v11).
