### PR TITLE
Fixing the Arel::Nodes::SqlLiteral Psych dump issue

### DIFF
--- a/lib/arel/nodes/sql_literal.rb
+++ b/lib/arel/nodes/sql_literal.rb
@@ -5,6 +5,14 @@ module Arel
       include Arel::Predications
       include Arel::AliasPredication
       include Arel::OrderPredications
+       
+      def encode_with(coder)
+        coder['string'] = self.to_s
+      end
+      
+      def init_with(coder)
+        self << coder['string']
+      end
     end
 
     class BindParam < SqlLiteral


### PR DESCRIPTION
I don't know if it is an acceptable solution; anyway, I defined custom `encode_with` and `init_with` methods for `Arel::Nodes::SqlLiteral` which restores the Psych dump of SqlLiteral instances (issue #149).
