### PR TITLE
Handle BigDecimal Ranges

### DIFF
--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -405,6 +405,29 @@ module Arel
           compile(node).must_be_like %{1=1}
         end
 
+        it 'can handle BigDecimal ranges bounded by infinity' do
+          node = @attr.in BigDecimal.new(1)..BigDecimal.new('Infinity')
+          compile(node).must_be_like %{
+            "users"."id" >= 1
+          }
+          node = @attr.in BigDecimal.new(1)...BigDecimal.new('Infinity')
+          compile(node).must_be_like %{
+            "users"."id" >= 1
+          }
+          node = @attr.in BigDecimal.new('-Infinity')..BigDecimal.new(3)
+          compile(node).must_be_like %{
+            "users"."id" <= 3
+          }
+          node = @attr.in BigDecimal.new('-Infinity')...BigDecimal.new(3)
+          compile(node).must_be_like %{
+            "users"."id" < 3
+          }
+          node = @attr.in BigDecimal.new('-Infinity')..BigDecimal.new('Infinity')
+          compile(node).must_be_like %{1=1}
+          node = @attr.in BigDecimal.new('-Infinity')...BigDecimal.new('Infinity')
+          compile(node).must_be_like %{1=1}
+        end
+
         it 'can handle subqueries' do
           table = Table.new(:users)
           subquery = table.project(:id).where(table[:name].eq('Aaron'))


### PR DESCRIPTION
Comparing a BigDecimal to `Float::INFINITY` throws a `FloatDomainError: Infinity` exception in ruby MRI 1.9+ and a `TypeError` on 1.8. This causes the comparisons in `Arel::Predications#in` and `#not_in` to fail when using BigDecimal values, which can often happen when using PostgreSQL and ActiveRecord, as AR casts `numeric` values in PostgreSQL to BigDecimal.
