### PR TITLE
Allow Fixnum values to be quoted

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -575,6 +575,7 @@ key on UpdateManager using UpdateManager#key=
       alias :visit_Hash                          :quoted
       alias :visit_NilClass                      :quoted
       alias :visit_String                        :quoted
+      alias :visit_Fixnum                        :quoted
       alias :visit_Symbol                        :quoted
       alias :visit_Time                          :quoted
       alias :visit_TrueClass                     :quoted

--- a/test/nodes/test_equality.rb
+++ b/test/nodes/test_equality.rb
@@ -43,7 +43,7 @@ module Arel
             attr = Table.new(:users)[:id]
             test = attr.eq(10)
             test.to_sql engine
-            engine.connection.quote_count.must_equal 2
+            engine.connection.quote_count.must_equal 3
           end
         end
       end

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -107,6 +107,10 @@ module FakeRecord
     def schema_cache
       connection
     end
+
+    def quote *args
+      connection.quote *args
+    end
   end
 
   class Base


### PR DESCRIPTION
Currently `User.where(id: '10')` would result in query where the
value is integer 10 instead of string 10. That's because id column is
of type 'Integer`.

However `User.where(name: 10)` would not result in value in string even though column name is of type "string"

This PR allows "Fixnum" to be quoted so that in ActiveRecord proper
quoting can be done based on column type.

Please see https://github.com/rails/rails/pull/11138 for the changes in ActiveRecord side. 