### PR TITLE
Remove static string literals from visitors

### DIFF
--- a/lib/arel/visitors/informix.rb
+++ b/lib/arel/visitors/informix.rb
@@ -4,22 +4,22 @@ module Arel
       private
       def visit_Arel_Nodes_SelectStatement o, a
         [
-          "SELECT",
+          SELECT,
           (visit(o.offset, a) if o.offset),
           (visit(o.limit, a) if o.limit),
           o.cores.map { |x| visit_Arel_Nodes_SelectCore x, a }.join,
-          ("ORDER BY #{o.orders.map { |x| visit x, a }.join(', ')}" unless o.orders.empty?),
+          ("ORDER BY #{o.orders.map { |x| visit x, a }.join(COMMA_)}" unless o.orders.empty?),
           (visit(o.lock, a) if o.lock),
-        ].compact.join ' '
+        ].compact.join SPACE
       end
       def visit_Arel_Nodes_SelectCore o, a
         [
-          "#{o.projections.map { |x| visit x, a }.join ', '}",
+          "#{o.projections.map { |x| visit x, a }.join COMMA_}",
           ("FROM #{visit(o.source, a)}" if o.source && !o.source.empty?),
-          ("WHERE #{o.wheres.map { |x| visit x, a }.join ' AND ' }" unless o.wheres.empty?),
-          ("GROUP BY #{o.groups.map { |x| visit x, a }.join ', ' }" unless o.groups.empty?),
+          ("WHERE #{o.wheres.map { |x| visit x, a }.join AND}" unless o.wheres.empty?),
+          ("GROUP BY #{o.groups.map { |x| visit x, a }.join COMMA_}" unless o.groups.empty?),
           (visit(o.having, a) if o.having),
-        ].compact.join ' '
+        ].compact.join SPACE
       end
       def visit_Arel_Nodes_Offset o, a
         "SKIP #{visit o.expr, a}"

--- a/lib/arel/visitors/join_sql.rb
+++ b/lib/arel/visitors/join_sql.rb
@@ -9,10 +9,12 @@ module Arel
     # This visitor is used in SelectManager#join_sql and is for backwards
     # compatibility with Arel V1.0
     module JoinSql
+      SPACE = ' '
+
       private
 
       def visit_Arel_Nodes_SelectCore o, a
-        o.source.right.map { |j| visit j, a }.join ' '
+        o.source.right.map { |j| visit j, a }.join SPACE
       end
     end
   end

--- a/lib/arel/visitors/mssql.rb
+++ b/lib/arel/visitors/mssql.rb
@@ -7,7 +7,7 @@ module Arel
       # "select top 10 distinct first_name from users", which is invalid query! it should be
       # "select distinct top 10 first_name from users"
       def visit_Arel_Nodes_Top o, a
-        ""
+        EMPTY
       end
 
       def visit_Arel_Nodes_SelectStatement o, a
@@ -15,7 +15,7 @@ module Arel
           return super o, a
         end
 
-        select_order_by = "ORDER BY #{o.orders.map { |x| visit x, a }.join(', ')}" unless o.orders.empty?
+        select_order_by = "ORDER BY #{o.orders.map { |x| visit x, a }.join(COMMA_)}" unless o.orders.empty?
 
         is_select_count = false
         sql = o.cores.map { |x|
@@ -48,7 +48,7 @@ module Arel
 
       def determine_order_by x, a
         unless x.groups.empty?
-          "ORDER BY #{x.groups.map { |g| visit g, a }.join ', ' }"
+          "ORDER BY #{x.groups.map { |g| visit g, a }.join COMMA_}"
         else
           "ORDER BY #{find_left_table_pk(x.froms, a)}"
         end

--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -37,18 +37,18 @@ module Arel
       end
 
       def visit_Arel_Nodes_SelectCore o, a
-        o.froms ||= Arel.sql('DUAL')
+        o.froms ||= Arel.sql(DUAL)
         super
       end
 
       def visit_Arel_Nodes_UpdateStatement o, a
         [
           "UPDATE #{visit o.relation, a}",
-          ("SET #{o.values.map { |value| visit value, a }.join ', '}" unless o.values.empty?),
-          ("WHERE #{o.wheres.map { |x| visit x, a }.join ' AND '}" unless o.wheres.empty?),
-          ("ORDER BY #{o.orders.map { |x| visit x, a }.join(', ')}" unless o.orders.empty?),
+          ("SET #{o.values.map { |value| visit value, a }.join COMMA_}" unless o.values.empty?),
+          ("WHERE #{o.wheres.map { |x| visit x, a }.join AND}" unless o.wheres.empty?),
+          ("ORDER BY #{o.orders.map { |x| visit x, a }.join(COMMA_)}" unless o.orders.empty?),
           (visit(o.limit, a) if o.limit),
-        ].compact.join ' '
+        ].compact.join SPACE
       end
 
     end

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -10,7 +10,7 @@ module Arel
         # then can use simple ROWNUM in WHERE clause
         if o.limit && o.orders.empty? && !o.offset && o.cores.first.projections.first !~ /^DISTINCT /
           o.cores.last.wheres.push Nodes::LessThanOrEqual.new(
-            Nodes::SqlLiteral.new('ROWNUM'), o.limit.expr
+            Nodes::SqlLiteral.new(ROWNUM), o.limit.expr
           )
           return super
         end
@@ -92,7 +92,7 @@ module Arel
         # orders   = o.orders.map { |x| visit x, a }.join(', ').split(',')
         orders   = o.orders.map do |x|
           string = visit x, a
-          if string.include?(',')
+          if string.include?(COMMA)
             split_order_string(string)
           else
             string
@@ -101,7 +101,7 @@ module Arel
         o.orders = []
         orders.each_with_index do |order, i|
           o.orders <<
-            Nodes::SqlLiteral.new("alias_#{i}__#{' DESC' if /\bdesc$/i === order}")
+            Nodes::SqlLiteral.new("alias_#{i}__#{DESC if /\bdesc$/i === order}")
         end
         o
       end
@@ -111,14 +111,13 @@ module Arel
       def split_order_string(string)
         array = []
         i = 0
-        string.split(',').each do |part|
+        string.split(COMMA).each do |part|
           if array[i]
-            array[i] << ',' << part
+            array[i] << COMMA << part
           else
-            # to ensure that array[i] will be String and not Arel::Nodes::SqlLiteral
-            array[i] = '' << part
+            array[i] = part.to_s
           end
-          i += 1 if array[i].count('(') == array[i].count(')')
+          i += 1 if array[i].count(LPAREN) == array[i].count(RPAREN)
         end
         array
       end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -45,18 +45,24 @@ module Arel
 
       # :stopdoc:
       AND         = ' AND '
-      COMMA       = ', '
+      COMMA       = ','
+      COMMA_      = ', '
       CURRENT_ROW = 'CURRENT ROW'
       DISTINCT    = 'DISTINCT'
       DISTINCT_   = 'DISTINCT '
+      DESC        = ' DESC'
+      DUAL        = 'DUAL'
       EMPTY       = ''
       FALSE       = 'FALSE'
       GROUP_BY    = ' GROUP BY '
+      LPAREN      = '('
       ONE_EQ_ONE  = "1=1"
       ONE_EQ_ZERO = "1=0"
       ORDER_BY    = ' ORDER BY '
       RANGE       = 'RANGE'
+      ROWNUM      = 'ROWNUM'
       ROWS        = 'ROWS'
+      RPAREN      = ')'
       SELECT      = 'SELECT'
       SPACE       = ' '
       TRUE        = 'TRUE'
@@ -112,7 +118,7 @@ key on UpdateManager using UpdateManager#key=
 
         [
           "UPDATE #{visit o.relation, a}",
-          ("SET #{o.values.map { |value| visit value, a }.join COMMA}" unless o.values.empty?),
+          ("SET #{o.values.map { |value| visit value, a }.join COMMA_}" unless o.values.empty?),
           ("WHERE #{wheres.map { |x| visit x, a }.join AND}" unless wheres.empty?),
         ].compact.join SPACE
       end
@@ -123,7 +129,7 @@ key on UpdateManager using UpdateManager#key=
 
           ("(#{o.columns.map { |x|
           quote_column_name x.name
-        }.join COMMA})" unless o.columns.empty?),
+        }.join COMMA_})" unless o.columns.empty?),
 
           (visit o.values, a if o.values),
         ].compact.join SPACE
@@ -167,7 +173,7 @@ key on UpdateManager using UpdateManager#key=
           else
             quote(value, attr && column_for(attr))
           end
-        }.join COMMA})"
+        }.join COMMA_})"
       end
 
       def visit_Arel_Nodes_SelectStatement o, a
@@ -186,7 +192,7 @@ key on UpdateManager using UpdateManager#key=
           len = o.orders.length - 1
           o.orders.each_with_index { |x, i|
             str << visit(x, a)
-            str << COMMA unless len == i
+            str << COMMA_ unless len == i
           }
         end
 
@@ -209,7 +215,7 @@ key on UpdateManager using UpdateManager#key=
           len = o.projections.length - 1
           o.projections.each_with_index do |x, i|
             str << visit(x, a)
-            str << COMMA unless len == i
+            str << COMMA_ unless len == i
           end
         end
 
@@ -229,7 +235,7 @@ key on UpdateManager using UpdateManager#key=
           len = o.groups.length - 1
           o.groups.each_with_index do |x, i|
             str << visit(x, a)
-            str << COMMA unless len == i
+            str << COMMA_ unless len == i
           end
         end
 
@@ -240,7 +246,7 @@ key on UpdateManager using UpdateManager#key=
           len = o.windows.length - 1
           o.windows.each_with_index do |x, i|
             str << visit(x, a)
-            str << COMMA unless len == i
+            str << COMMA_ unless len == i
           end
         end
 
@@ -260,11 +266,11 @@ key on UpdateManager using UpdateManager#key=
       end
 
       def visit_Arel_Nodes_With o, a
-        "WITH #{o.children.map { |x| visit x, a }.join(COMMA)}"
+        "WITH #{o.children.map { |x| visit x, a }.join(COMMA_)}"
       end
 
       def visit_Arel_Nodes_WithRecursive o, a
-        "WITH RECURSIVE #{o.children.map { |x| visit x, a }.join(COMMA)}"
+        "WITH RECURSIVE #{o.children.map { |x| visit x, a }.join(COMMA_)}"
       end
 
       def visit_Arel_Nodes_Union o, a
@@ -289,7 +295,7 @@ key on UpdateManager using UpdateManager#key=
 
       def visit_Arel_Nodes_Window o, a
         s = [
-          ("ORDER BY #{o.orders.map { |x| visit(x, a) }.join(COMMA)}" unless o.orders.empty?),
+          ("ORDER BY #{o.orders.map { |x| visit(x, a) }.join(COMMA_)}" unless o.orders.empty?),
           (visit o.framing, a if o.framing)
         ].compact.join SPACE
         "(#{s})"
@@ -380,7 +386,7 @@ key on UpdateManager using UpdateManager#key=
       def visit_Arel_Nodes_NamedFunction o, a
         "#{o.name}(#{o.distinct ? DISTINCT_ : EMPTY}#{o.expressions.map { |x|
           visit x, a
-        }.join(COMMA)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
+        }.join(COMMA_)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
       end
 
       def visit_Arel_Nodes_Extract o, a
@@ -390,27 +396,27 @@ key on UpdateManager using UpdateManager#key=
       def visit_Arel_Nodes_Count o, a
         "COUNT(#{o.distinct ? DISTINCT_ : EMPTY}#{o.expressions.map { |x|
           visit x, a
-        }.join(COMMA)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
+        }.join(COMMA_)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
       end
 
       def visit_Arel_Nodes_Sum o, a
         "SUM(#{o.distinct ? DISTINCT_ : EMPTY}#{o.expressions.map { |x|
-          visit x, a }.join(COMMA)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
+          visit x, a }.join(COMMA_)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
       end
 
       def visit_Arel_Nodes_Max o, a
         "MAX(#{o.distinct ? DISTINCT_ : EMPTY}#{o.expressions.map { |x|
-          visit x, a }.join(COMMA)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
+          visit x, a }.join(COMMA_)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
       end
 
       def visit_Arel_Nodes_Min o, a
         "MIN(#{o.distinct ? DISTINCT_ : EMPTY}#{o.expressions.map { |x|
-          visit x, a }.join(COMMA)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
+          visit x, a }.join(COMMA_)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
       end
 
       def visit_Arel_Nodes_Avg o, a
         "AVG(#{o.distinct ? DISTINCT_ : EMPTY}#{o.expressions.map { |x|
-          visit x, a }.join(COMMA)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
+          visit x, a }.join(COMMA_)})#{o.alias ? " AS #{visit o.alias, a}" : EMPTY}"
       end
 
       def visit_Arel_Nodes_TableAlias o, a
@@ -601,7 +607,7 @@ key on UpdateManager using UpdateManager#key=
       alias :visit_Arel_Nodes_Division       :visit_Arel_Nodes_InfixOperation
 
       def visit_Array o, a
-        o.map { |x| visit x, a }.join(COMMA)
+        o.map { |x| visit x, a }.join(COMMA_)
       end
 
       def quote value, column = nil

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -425,14 +425,20 @@ module Arel
 
       if defined?(RubyVM::InstructionSequence.of) # CRuby >= 2.0.0
         it "should not contain any static string literals in visitor methods" do
-          method_iseqs = ToSql.private_instance_methods(false)
-            .map { |mid| ToSql.instance_method(mid) }
-            .map { |method| RubyVM::InstructionSequence.of(method) }
+          excluded = [:Dot]
+          (Arel::Visitors.constants - excluded).each do |const_name|
+            klass = Arel::Visitors.const_get(const_name)
+            next unless klass.respond_to?(:private_instance_methods)
 
-          method_iseqs.each do |iseq|
-            instructions = iseq.to_a[13]
-            if instructions.any? { |opcode,| opcode == :putstring }
-              flunk "#{iseq.label} contains static string literal(s). Please change these to constant references."
+            method_iseqs = klass.private_instance_methods(false)
+              .map { |mid| klass.instance_method(mid) }
+              .map { |method| RubyVM::InstructionSequence.of(method) }
+
+            method_iseqs.each do |iseq|
+              instructions = iseq.to_a[13]
+              if instructions.any? { |opcode,| opcode == :putstring }
+                flunk "#{klass}##{iseq.label} contains static string literal(s). Please change these to constant references."
+              end
             end
           end
         end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -422,6 +422,21 @@ module Arel
           end
         end
       end
+
+      if defined?(RubyVM::InstructionSequence.of) # CRuby >= 2.0.0
+        it "should not contain any static string literals in visitor methods" do
+          method_iseqs = ToSql.private_instance_methods(false)
+            .map { |mid| ToSql.instance_method(mid) }
+            .map { |method| RubyVM::InstructionSequence.of(method) }
+
+          method_iseqs.each do |iseq|
+            instructions = iseq.to_a[13]
+            if instructions.any? { |opcode,| opcode == :putstring }
+              flunk "#{iseq.label} contains static string literal(s). Please change these to constant references."
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request removes all static string literals that would ordinarily be duped for no reason from visitor methods.

I've also added a test case to ensure that no static string literals are ever put in visitor method bodies in future.

cc @fxn