### PR TITLE
Cache visitor dispatch on a per-visitor basis

### DIFF
--- a/lib/arel/visitors/visitor.rb
+++ b/lib/arel/visitors/visitor.rb
@@ -7,12 +7,15 @@ module Arel
 
       private
 
-      DISPATCH = Hash.new do |hash, klass|
-        hash[klass] = "visit_#{(klass.name || '').gsub('::', '_')}"
+      DISPATCH = Hash.new do |hash, visitor_class|
+        hash[visitor_class] =
+          Hash.new do |hash, node_class|
+            hash[node_class] = "visit_#{(node_class.name || '').gsub('::', '_')}"
+          end
       end
 
       def dispatch
-        DISPATCH
+        DISPATCH[self.class]
       end
 
       def visit object, attribute = nil

--- a/test/visitors/test_dispatch_contamination.rb
+++ b/test/visitors/test_dispatch_contamination.rb
@@ -1,0 +1,22 @@
+require 'helper'
+
+module Arel
+  module Visitors
+    describe 'avoiding contamination between visitor dispatch tables' do
+      before do
+        @connection = Table.engine.connection
+        @table = Table.new(:users)
+      end
+
+      it 'dispatches properly after failing upwards' do
+        node = Nodes::Union.new(Nodes::True.new, Nodes::False.new)
+        assert_equal "( TRUE UNION FALSE )", node.to_sql
+
+        node.first # from Nodes::Node's Enumerable mixin
+
+        assert_equal "( TRUE UNION FALSE )", node.to_sql
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Currently, visitor dispatch (via the `DISPATCH`) constant is cached on a global basis. This means that, for instance, `Arel::Nodes::Union` will work fine when you use visitors implementing `visit_Arel_Nodes_Union` directly, like `Visitors::ToSql`. 

But if a visitor needs to go up the class hierarchy looking for the method, the dispatch table gets mutated. This is fine as a cache for a specific visitor class, assuming methods don't get added dynamically to the visitor classes (anybody doing that should probably expect problems anyway). But for this mutation to ruin other visitors' dispatch cache seems bad.

So this patch turns `DISPATCH` into a 2-level hash, first for the visitor class, then for the node class.

The alternatives I see are:
- depend on clients to avoid calling methods implemented in ancestor classes (not awesome; they'd have to depend on implementation details)
- get rid of this cache entirely (bad; presumably the cache is there for perf reasons)
- depend on clients to call `Arel::Visitors::Visitor::DISPATCH.clear` (bad; they'd lose the perf benefits and have ugly code)

Thoughts?
