### PR TITLE
Improve performance of #uniq across a large number of nodes

### DIFF
--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -124,7 +124,10 @@ Arel 4.0.0 with no replacement.  PEW PEW PEW!!!
     end
 
     def hash
-      [@name, @engine, @aliases, @table_alias].hash
+      # Perf note: aliases, table alias and engine is excluded from the hash
+      #  aliases can have a loop back to this table breaking hashes in parent
+      #  relations, for the vast majority of cases @name is unique to a query
+      @name.hash
     end
 
     def eql? other


### PR DESCRIPTION
Been chasing performance regressions in arel after upgrading to rails 4. This fixes 

https://github.com/rails/arel/issues/205

Before:

![image](https://f.cloud.github.com/assets/5213/1055453/31361996-1139-11e3-9b09-fe3cda6561aa.png)

After:

![image](https://f.cloud.github.com/assets/5213/1055468/a0452cb4-1139-11e3-8c01-4f9980e87161.png)

This is a mild improvement, I am chasing 10 missing milliseconds so every one counts :) 

For context, Rails 3 has a way faster arel ... here is the same page in Rails 3. 

![image](https://f.cloud.github.com/assets/5213/1055478/193dc81a-113a-11e3-9ef7-6d915db6f5ef.png)
