### PR TITLE
Added support of nulls first/last expression

### DIFF
--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -15,6 +15,7 @@ require 'arel/nodes/false'
 # unary
 require 'arel/nodes/unary'
 require 'arel/nodes/grouping'
+require 'arel/nodes/ordering'
 require 'arel/nodes/ascending'
 require 'arel/nodes/descending'
 require 'arel/nodes/unqualified_column'

--- a/lib/arel/nodes/ascending.rb
+++ b/lib/arel/nodes/ascending.rb
@@ -3,7 +3,7 @@ module Arel
     class Ascending < Ordering
 
       def reverse
-        Descending.new(expr)
+        Descending.new(expr, nulls: reverse_nulls)
       end
 
       def direction

--- a/lib/arel/nodes/descending.rb
+++ b/lib/arel/nodes/descending.rb
@@ -3,7 +3,7 @@ module Arel
     class Descending < Ordering
 
       def reverse
-        Ascending.new(expr)
+        Ascending.new(expr, nulls: reverse_nulls)
       end
 
       def direction

--- a/lib/arel/nodes/ordering.rb
+++ b/lib/arel/nodes/ordering.rb
@@ -1,0 +1,27 @@
+module Arel
+  module Nodes
+    class Ordering < Unary
+      REVERSE_NULLS = { first: :last, last: :first }
+
+      attr_accessor :nulls
+
+      def initialize(expr, options = {})
+        super(expr)
+        @nulls = options[:nulls]
+      end
+
+      def hash
+        [@expr, @nulls].hash
+      end
+
+      def eql?(other)
+        super && self.nulls == other.nulls
+      end
+
+      protected
+        def reverse_nulls
+          REVERSE_NULLS.fetch(nulls, nil)
+        end
+    end
+  end
+end

--- a/lib/arel/nodes/unary.rb
+++ b/lib/arel/nodes/unary.rb
@@ -27,7 +27,6 @@ module Arel
       Not
       Offset
       On
-      Ordering
       Top
       Lock
       DistinctOn

--- a/lib/arel/order_predications.rb
+++ b/lib/arel/order_predications.rb
@@ -1,12 +1,12 @@
 module Arel
   module OrderPredications
 
-    def asc
-      Nodes::Ascending.new self
+    def asc(*args)
+      Nodes::Ascending.new self, *args
     end
 
-    def desc
-      Nodes::Descending.new self
+    def desc(*args)
+      Nodes::Descending.new self, *args
     end
 
   end

--- a/lib/arel/visitors/ibm_db.rb
+++ b/lib/arel/visitors/ibm_db.rb
@@ -8,7 +8,6 @@ module Arel
         collector = visit o.expr, collector
         collector << " ROWS ONLY"
       end
-
     end
   end
 end

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -115,6 +115,12 @@ module Arel
         o
       end
 
+      def visit_ordering_expr(o, collector, direction)
+        collector = visit(o.expr, collector) << ' ' << direction
+        collector << " NULLS #{o.nulls.to_s.upcase}" if o.nulls
+        collector
+      end
+
       # Split string by commas but count opening and closing brackets
       # and ignore commas inside brackets.
       def split_order_string(string)

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -43,6 +43,12 @@ module Arel
       def visit_Arel_Nodes_BindParam o, collector
         collector.add_bind(o) { |i| "$#{i}" }
       end
+
+      def visit_ordering_expr(o, collector, direction)
+        collector = visit(o.expr, collector) << ' ' << direction
+        collector << " NULLS #{o.nulls.to_s.upcase}" if o.nulls
+        collector
+      end
     end
   end
 end

--- a/test/nodes/test_ascending.rb
+++ b/test/nodes/test_ascending.rb
@@ -39,6 +39,20 @@ module Arel
         array = [Ascending.new('zomg'), Ascending.new('zomg!')]
         assert_equal 2, array.uniq.size
       end
+
+      def test_accept_nulls_first_last_option
+        ascending = Ascending.new('zomg')
+        assert_nil ascending.nulls
+
+        ascending = Ascending.new('zomg', nulls: :first)
+        assert_equal :first, ascending.nulls
+      end
+
+      def test_reverse_with_nulls
+        ascending = Ascending.new('zomg', nulls: :first)
+        descending = ascending.reverse
+        assert_equal :last, descending.nulls
+      end
     end
   end
 end

--- a/test/nodes/test_descending.rb
+++ b/test/nodes/test_descending.rb
@@ -39,6 +39,24 @@ module Arel
         array = [Descending.new('zomg'), Descending.new('zomg!')]
         assert_equal 2, array.uniq.size
       end
+
+      def test_accept_nulls_first_last_option
+        ascending = Descending.new('zomg')
+        assert_nil ascending.nulls
+
+        ascending = Descending.new('zomg', nulls: :first)
+        assert_equal :first, ascending.nulls
+
+        ascending = Descending.new('zomg', nulls: :last)
+        assert_equal :last, ascending.nulls
+      end
+
+      def test_reverse_with_nulls
+        ascending = Descending.new('zomg', nulls: :last)
+        descending = ascending.reverse
+        assert_equal 'zomg', descending.expr
+        assert_equal :first, descending.nulls
+      end
     end
   end
 end

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -461,6 +461,17 @@ module Arel
           SELECT * FROM "users" ORDER BY "users"."id" DESC
         }
       end
+
+      it 'supports nulls last with asc' do
+        table   = Table.new :users
+        manager = Arel::SelectManager.new
+        manager.project Nodes::SqlLiteral.new '*'
+        manager.from table
+        manager.order table[:id].asc(nulls: :last)
+        manager.to_sql.must_be_like %{
+          SELECT * FROM "users" ORDER BY CASE WHEN "users"."id" IS NULL THEN 0 ELSE 1 END DESC, "users"."id" ASC
+        }
+      end
     end
 
     describe 'on' do

--- a/test/visitors/test_ibm_db.rb
+++ b/test/visitors/test_ibm_db.rb
@@ -27,7 +27,6 @@ module Arel
         sql = compile(stmt)
         sql.must_be_like "UPDATE \"users\" WHERE \"users\".\"id\" IN (SELECT \"users\".\"id\" FROM \"users\" FETCH FIRST 1 ROWS ONLY)"
       end
-
     end
   end
 end

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -24,6 +24,20 @@ module Arel
         }
       end
 
+      it 'should support NULLS FIRST/LAST' do
+        compile(Nodes::Ascending.new(Nodes::SqlLiteral.new('omg'))).must_be_like %{
+           omg ASC
+        }
+
+        compile(Nodes::Ascending.new(Nodes::SqlLiteral.new('omg'), nulls: :first)).must_be_like %{
+          omg ASC NULLS FIRST
+        }
+
+        compile(Nodes::Descending.new(Nodes::SqlLiteral.new('omg'), nulls: :last)).must_be_like %{
+          omg DESC NULLS LAST
+        }
+      end
+
       it 'is idempotent with crazy query' do
         # *sigh*
         select = "DISTINCT foo.id, FIRST_VALUE(projects.name) OVER (foo) AS alias_0__"

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -182,6 +182,12 @@ module Arel
           }
         end
       end
+
+      it 'should support NULLS FIRST/LAST' do
+        compile(@attr.asc).must_be_like %{ "users"."id" ASC }
+        compile(@attr.asc(nulls: :first)).must_be_like %{ "users"."id" ASC NULLS FIRST }
+        compile(@attr.asc(nulls: :last)).must_be_like %{ "users"."id" ASC NULLS LAST }
+      end
     end
   end
 end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -373,6 +373,18 @@ module Arel
             "users"."id" DESC
           }
         end
+
+        it 'should support NULLS FIRST' do
+          node = @attr.asc(nulls: :first)
+          compile(node).
+            must_match /CASE WHEN "users"."id" IS NULL THEN 0 ELSE 1 END ASC, "users"."id" ASC\Z/
+        end
+
+        it 'should support NULLS LAST' do
+          node = @attr.desc(nulls: :last)
+          compile(node).must_match /CASE WHEN "users"."id" IS NULL THEN 0 ELSE 1 END DESC, "users"."id" DESC\Z/
+        end
+
       end
 
       describe "Nodes::In" do


### PR DESCRIPTION
In order that in SQL specification there is option for order how to sort nulls values`ORDER BY name DESC NULLS LAST`, added to Ordering node nulls order direction option.
