### PR TITLE
Support `columns_for_distinct` with Oracle adapter

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -8,7 +8,7 @@ module Arel
 
         # if need to select first records without ORDER BY and GROUP BY and without DISTINCT
         # then can use simple ROWNUM in WHERE clause
-        if o.limit && o.orders.empty? && !o.offset && o.cores.first.projections.first !~ /^DISTINCT /
+        if o.limit && o.orders.empty? && !o.offset && o.cores.first.set_quantifier.class.to_s !~ /Distinct/
           o.cores.last.wheres.push Nodes::LessThanOrEqual.new(
             Nodes::SqlLiteral.new('ROWNUM'), o.limit.expr
           )
@@ -83,7 +83,7 @@ module Arel
         return o if o.orders.empty?
         return o unless o.cores.any? do |core|
           core.projections.any? do |projection|
-            /DISTINCT.*FIRST_VALUE/ === projection
+            /FIRST_VALUE/ === projection
           end
         end
         # Previous version with join and split broke ORDER BY clause

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -85,7 +85,8 @@ module Arel
 
           it 'creates a subquery when there is DISTINCT' do
             stmt = Nodes::SelectStatement.new
-            stmt.cores.first.projections << Nodes::SqlLiteral.new('DISTINCT id')
+            stmt.cores.first.set_quantifier = Arel::Nodes::Distinct.new
+            stmt.cores.first.projections << Nodes::SqlLiteral.new('id')
             stmt.limit = Arel::Nodes::Limit.new(10)
             sql = @visitor.accept stmt
             sql.must_be_like %{


### PR DESCRIPTION
Since rails/rails#6792 merged to rails, ActiveRecord supports `columns_for_distinct` then `distinct` method willbe deprecated.

Although Oracle enhanced adapter suppports `columns_for_distinct` method in rsim/oracle-enhanced#340. To make this change work Arel support is necessary because `distinct_columns` method does not provide the `DISTINCT` to predictions. `visit_Arel_Nodes_SelectStatement` and `order_hacks` method uses conditions to see if `DISTINCT` is inside of projections.

I was able to find to use `set_quantifier` in `visit_Arel_Nodes_SelectStatement`, which makes every Oracle enhanced adapter unit test and ActiveRecord unit test works, still getting Arel unit test failure. 

It would be very helpful if someone review my pull request and give some feedback.
