### PR TITLE
Add multiple values to a single insert

### DIFF
--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -38,6 +38,7 @@ require 'arel/nodes/function'
 require 'arel/nodes/count'
 require 'arel/nodes/extract'
 require 'arel/nodes/values'
+require 'arel/nodes/extra_values'
 require 'arel/nodes/named_function'
 
 # windows

--- a/lib/arel/nodes/extra_values.rb
+++ b/lib/arel/nodes/extra_values.rb
@@ -1,0 +1,12 @@
+module Arel
+  module Nodes
+    class ExtraValues < Arel::Nodes::Node
+      attr_accessor :values
+
+      def initialize values
+        @values = values.is_a?(Array) ? values : [values]
+        super()
+      end
+    end
+  end
+end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -115,6 +115,16 @@ key on UpdateManager using UpdateManager#key=
         }.join ', '})"
       end
 
+      def visit_Arel_Nodes_ExtraValues o
+        "(#{o.values.map { |value|
+          if Nodes::SqlLiteral === value
+            visit value
+          else
+            quote(value)
+          end
+        }.join ', '})"
+      end
+
       def visit_Arel_Nodes_SelectStatement o
         [
           (visit(o.with) if o.with),

--- a/test/test_insert_manager.rb
+++ b/test/test_insert_manager.rb
@@ -139,6 +139,22 @@ module Arel
           INSERT INTO "users" ("id", "name") VALUES (1, 'aaron')
         }
       end
+
+      it "adds more values to single insert" do
+        table   = Table.new :users
+        manager = Arel::InsertManager.new Table.engine
+        manager.into table
+
+        manager.values = [
+          Nodes::Values.new([1, 'aaron']),
+          Nodes::ExtraValues.new([2, 'joe'])
+        ]
+        manager.columns << table[:id]
+        manager.columns << table[:name]
+        manager.to_sql.must_be_like %{
+          INSERT INTO "users" ("id", "name") VALUES (1, 'aaron'), (2, 'joe')
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Makes possible to put a set of records in a single insert:

``` sql
INSERT INTO "users" ("id", "name") VALUES (1, 'aaron'), (2, 'joe')
```
