### PR TITLE
Adds PostgreSQL support for IPAddr

### DIFF
--- a/lib/arel.rb
+++ b/lib/arel.rb
@@ -1,3 +1,4 @@
+require 'ipaddr'
 require 'arel/crud'
 require 'arel/factory_methods'
 

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -14,6 +14,10 @@ module Arel
       def visit_Arel_Nodes_DistinctOn o, a
         "DISTINCT ON ( #{visit o.expr, a} )"
       end
+
+      def visit_IPAddr o, a
+        "'#{o.to_s}/#{o.instance_variable_get(:@mask_addr).to_s(2).count('1')}'"
+      end
     end
   end
 end

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -43,6 +43,12 @@ module Arel
         core.set_quantifier = Arel::Nodes::Distinct.new
         assert_equal 'SELECT DISTINCT', @visitor.accept(core)
       end
+
+      it 'should support IPAddr with subnet' do
+        table = Table.new(:visitors)
+        node = table[:ip_address].eq(IPAddr.new('127.0.0.1'))
+        assert_match /'127.0.0.1\/32/, @visitor.accept(node)
+      end
     end
   end
 end


### PR DESCRIPTION
PostgreSQL support INET and CIDR addresses, which include the subnet of the IP address. This commit adds support for converting IPAddr values into the proper string in PostgreSQL
