### PR TITLE
Add support for lock in Update and Delete.

### DIFF
--- a/lib/arel/crud.rb
+++ b/lib/arel/crud.rb
@@ -14,6 +14,7 @@ module Arel
       um.set values
       um.take @ast.limit.expr if @ast.limit
       um.order(*@ast.orders)
+      um.lock(@ast.lock.expr) if @ast.lock
       um.wheres = @ctx.wheres
       um
     end
@@ -56,6 +57,7 @@ switch to `compile_insert`
       dm = DeleteManager.new @engine
       dm.wheres = @ctx.wheres
       dm.from @ctx.froms
+      dm.lock @ast.lock.expr if @ast.lock
       dm
     end
 

--- a/lib/arel/delete_manager.rb
+++ b/lib/arel/delete_manager.rb
@@ -1,5 +1,9 @@
+require 'arel/lock_manager'
+
 module Arel
   class DeleteManager < Arel::TreeManager
+    include Arel::LockManager
+
     def initialize engine
       super
       @ast = Nodes::DeleteStatement.new

--- a/lib/arel/lock_manager.rb
+++ b/lib/arel/lock_manager.rb
@@ -1,0 +1,20 @@
+module Arel
+  module LockManager
+    def lock locking = Arel.sql('FOR UPDATE')
+      case locking
+      when true
+        locking = Arel.sql('FOR UPDATE')
+      when Arel::Nodes::SqlLiteral
+      when String
+        locking = Arel.sql locking
+      end
+
+      @ast.lock = Nodes::Lock.new(locking)
+      self
+    end
+
+    def locked
+      @ast.lock
+    end
+  end
+end

--- a/lib/arel/nodes/delete_statement.rb
+++ b/lib/arel/nodes/delete_statement.rb
@@ -6,6 +6,8 @@ module Arel
       alias :wheres :right
       alias :wheres= :right=
 
+      attr_accessor :lock
+
       def initialize relation = nil, wheres = []
         super
       end

--- a/lib/arel/nodes/update_statement.rb
+++ b/lib/arel/nodes/update_statement.rb
@@ -2,7 +2,7 @@ module Arel
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
       attr_accessor :relation, :wheres, :values, :orders, :limit
-      attr_accessor :key
+      attr_accessor :key, :lock
 
       def initialize
         @relation = nil

--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -1,6 +1,9 @@
+require 'arel/lock_manager'
+
 module Arel
   class SelectManager < Arel::TreeManager
     include Arel::Crud
+    include Arel::LockManager
 
     def initialize engine, table = nil
       super(engine)
@@ -53,23 +56,6 @@ module Arel
       end
       to_sql = Visitors::ToSql.new @engine.connection
       @ctx.wheres.map { |c| to_sql.accept c }
-    end
-
-    def lock locking = Arel.sql('FOR UPDATE')
-      case locking
-      when true
-        locking = Arel.sql('FOR UPDATE')
-      when Arel::Nodes::SqlLiteral
-      when String
-        locking = Arel.sql locking
-      end
-
-      @ast.lock = Nodes::Lock.new(locking)
-      self
-    end
-
-    def locked
-      @ast.lock
     end
 
     def on *exprs

--- a/lib/arel/update_manager.rb
+++ b/lib/arel/update_manager.rb
@@ -1,5 +1,9 @@
+require 'arel/lock_manager'
+
 module Arel
   class UpdateManager < Arel::TreeManager
+    include Arel::LockManager
+
     def initialize engine
       super
       @ast = Nodes::UpdateStatement.new


### PR DESCRIPTION
MSSQL allow you to specify a lock hint for SELECT, UPDATE and DELETE.
To support this, UpdateStatement, DeleteStatement and their manager counterpart need to allow a lock value.

I've extracted the lock business in a separate module included in the SelectTatement, UpdateStatement and DeleteStatement.

This pull request is the first step for this: https://github.com/jruby/activerecord-jdbc-adapter/issues/494
When accepted I'll apply the same modification for the 4-0-stable branch and master branch.