### PR TITLE
Documented the case-insensitive nature of the match feature.

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -42,6 +42,10 @@ module Arel
       # `getconstant` should be a hash lookup, and no object is duped when the
       # value of the constant is pushed on the stack.  Hence the crazy
       # constants below.
+      #
+      # `matches` and `doesNotMatch` operate case-insensitively via Visitor subclasses
+      # specialized for specific databases when necessary.
+      #
 
       WHERE    = ' WHERE '    # :nodoc:
       SPACE    = ' '          # :nodoc:


### PR DESCRIPTION
Documenting Arel's behavior. People and other libraries have come to expect this behavior, and so am submitting this pull request to specify it authoritatively. See e.g. http://railscasts.com/episodes/354-squeel?view=asciicast ("this will perform a case-insensitive search no matter what database is being used.)
