### PR TITLE
Make an ast for compile_update as needed

### DIFF
--- a/lib/arel/crud.rb
+++ b/lib/arel/crud.rb
@@ -3,6 +3,8 @@ module Arel
   # FIXME hopefully we can remove this
   module Crud
     def compile_update values, pk
+      return select_manager.compile_update(values, pk) if @ast.nil?
+
       um = UpdateManager.new @engine
 
       if Nodes::SqlLiteral === values
@@ -31,8 +33,13 @@ module Arel
 
     def compile_delete
       dm = DeleteManager.new @engine
-      dm.wheres = @ctx.wheres
-      dm.from @ctx.froms
+      if @ast.nil?
+        dm.from self
+      else
+        dm.wheres = @ctx.wheres
+        dm.from @ctx.froms
+      end
+
       dm
     end
 

--- a/test/test_crud.rb
+++ b/test/test_crud.rb
@@ -59,5 +59,32 @@ module Arel
         assert_instance_of Arel::DeleteManager, stmt
       end
     end
+
+    it 'allows an insert on table without manager' do
+      table   = Table.new :users
+      stmt = table.compile_insert({table[:id] => 1})
+
+      stmt.to_sql.must_be_like %{
+        INSERT INTO "users" ("id") VALUES (1)
+      }
+    end
+
+    it 'allows an update on table without manager' do
+      table   = Table.new :users
+      stmt = table.compile_update({table[:id] => 1}, Arel::Attributes::Attribute.new(table, 'id'))
+
+      stmt.to_sql.must_be_like %{
+        UPDATE "users" SET "id" = 1
+      }
+    end
+
+    it 'allows a delete on table without manager' do
+      table   = Table.new :users
+      stmt = table.compile_delete
+
+      stmt.to_sql.must_be_like %{
+        DELETE FROM "users"
+      }
+    end
   end
 end


### PR DESCRIPTION
`my_table.compile_update(whatever)` alone crashes because the ast is nil, whereas both `my_table.where(something).compile_update(whatever)` and `my_table.select_manager.compile_update(whatever)` have their way.

This lets the problematic case behave like the latter.

This might apply to `compile_insert` and `compile_delete` as well.
