### PR TITLE
Allow assignment right member to reference columns

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -501,8 +501,13 @@ module Arel
       end
 
       def visit_Arel_Nodes_Assignment o, a
-        right = quote(o.right, column_for(o.left))
-        "#{visit o.left, a} = #{right}"
+        case o.right
+        when Arel::Nodes::UnqualifiedColumn, Arel::Attributes::Attribute
+          "#{visit o.left, a} = #{visit o.right, a}"
+        else
+          right = quote(o.right, column_for(o.left))
+          "#{visit o.left, a} = #{right}"
+        end
       end
 
       def visit_Arel_Nodes_Equality o, a


### PR DESCRIPTION
Such queries become possible for mortals:

``` ruby
table.where(table[:qux].eq 'zomg').compile_update(table[:foo] => table[:bar])
```

Arguably much more sane than using `engine.connection.quote_column_name`
or `engine.connection.visitor.accept` on the right hand (bar), which is
totally leaking the abstraction.
