### PR TITLE
Ensure Nodes::In and Nodes::NotIn know how to handle arrays with nil values

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -479,7 +479,16 @@ module Arel
           '1=0'
         else
           a = o.left if Arel::Attributes::Attribute === o.left
-          "#{visit o.left, a} IN (#{visit o.right, a})"
+          if Array === o.right && o.right.size != o.right.compact.size
+            c = o.right.compact
+            if c.empty?
+              "#{visit o.left, a} IS NULL"
+            else
+              "(#{visit o.left, a} IN (#{visit c, a}) OR #{visit o.left, a} IS NULL)"
+            end
+          else
+            "#{visit o.left, a} IN (#{visit o.right, a})"
+          end
         end
       end
 
@@ -488,7 +497,16 @@ module Arel
           '1=1'
         else
           a = o.left if Arel::Attributes::Attribute === o.left
-          "#{visit o.left, a} NOT IN (#{visit o.right, a})"
+          if Array === o.right && o.right.size != o.right.compact.size
+            c = o.right.compact
+            if c.empty?
+              "#{visit o.left, a} IS NOT NULL"
+            else
+              "(#{visit o.left, a} NOT IN (#{visit c, a}) AND #{visit o.left, a} IS NOT NULL)"
+            end
+          else
+            "#{visit o.left, a} NOT IN (#{visit o.right, a})"
+          end
         end
       end
 

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -274,6 +274,20 @@ module Arel
           @visitor.accept(node).must_equal '1=0'
         end
 
+        it "should handle nil" do
+          node = @attr.in [1, 2, nil]
+          @visitor.accept(node).must_be_like %{
+            ("users"."id" IN (1, 2) OR "users"."id" IS NULL)
+          }
+        end
+
+        it "should handle an array with nil values" do
+          node = @attr.in [nil]
+          @visitor.accept(node).must_be_like %{
+            "users"."id" IS NULL
+          }
+        end
+
         it 'can handle two dot ranges' do
           node = @attr.in 1..3
           @visitor.accept(node).must_be_like %{
@@ -375,6 +389,20 @@ module Arel
         it "should return 1=1 when empty right which is always true" do
           node = @attr.not_in []
           @visitor.accept(node).must_equal '1=1'
+        end
+
+        it "should handle nil" do
+          node = @attr.not_in [1, 2, nil]
+          @visitor.accept(node).must_be_like %{
+            ("users"."id" NOT IN (1, 2) AND "users"."id" IS NOT NULL)
+          }
+        end
+
+        it "should handle an array with nil values" do
+          node = @attr.not_in [nil]
+          @visitor.accept(node).must_be_like %{
+            "users"."id" IS NOT NULL
+          }
         end
 
         it 'can handle two dot ranges' do


### PR DESCRIPTION
Currently `Nodes::In` and `Nodes::NotIn` do not take into account if an array has a nil value, so it generates queries like `"users"."id" IN (NULL)` and `"users"."id" NOT IN (1, 2, NULL)`. This patch ensures the queries become `"users"."id" IS NULL` and `("users"."id" NOT IN (1, 2) AND "users"."id" IS NOT NULL)`

Note that IN empty array `[]` still generates `1=0` and NOT IN empty array `[]` still generates `1=1`.

I think this also fixes issue #227.

| Method | Argument | Before this patch | After this patch |
| --- | --- | --- | --- |
| In | `[]` | `1=0` | `1=0` |
| In | `[nil]` | `"users"."id" IN (NULL)` | `"users"."id" IS NULL` |
| In | `[1, 2, nil]` | `"users"."id" IN (1, 2, NULL)` | `("users"."id" IN (1, 2) OR "users"."id" IS NULL)` |
| NotIn | `[]` | `1=1` | `1=1` |
| NotIn | `[nil]` | `"users"."id" NOT IN (NULL)` | `"users"."id" IS NOT NULL` |
| NotIn | `[1, 2, nil]` | `"users"."id" NOT IN (1, 2, NULL)` | `("users"."id" NOT IN (1, 2) AND "users"."id" IS NOT NULL)` |
