### PR TITLE
Add Regexp and NotRegexp nodes for PostgreSQL

### DIFF
--- a/lib/arel/nodes/binary.rb
+++ b/lib/arel/nodes/binary.rb
@@ -40,7 +40,9 @@ module Arel
       Matches
       NotEqual
       NotIn
+      NotRegexp
       Or
+      Regexp
       Union
       UnionAll
       Intersect

--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -79,8 +79,10 @@ module Arel
       alias :visit_Arel_Nodes_Matches            :binary
       alias :visit_Arel_Nodes_NotEqual           :binary
       alias :visit_Arel_Nodes_NotIn              :binary
+      alias :visit_Arel_Nodes_NotRegexp          :binary
       alias :visit_Arel_Nodes_Or                 :binary
       alias :visit_Arel_Nodes_OuterJoin          :binary
+      alias :visit_Arel_Nodes_Regexp             :binary
       alias :visit_Arel_Nodes_RightOuterJoin     :binary
       alias :visit_Arel_Nodes_TableAlias         :binary
       alias :visit_Arel_Nodes_Values             :binary

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -11,6 +11,14 @@ module Arel
         "#{visit o.left} NOT ILIKE #{visit o.right}"
       end
 
+      def visit_Arel_Nodes_Regexp o
+        "#{visit o.left} ~ #{visit o.right}"
+      end
+
+      def visit_Arel_Nodes_NotRegexp o
+        "#{visit o.left} !~ #{visit o.right}"
+      end
+
       def visit_Arel_Nodes_DistinctOn o
         "DISTINCT ON ( #{visit o.expr} )"
       end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -435,6 +435,14 @@ module Arel
         "#{visit o.left} NOT LIKE #{visit o.right}"
       end
 
+      def visit_Arel_Nodes_Regexp o
+        raise NotImplementedError, '~ not implemented for this db'
+      end
+
+      def visit_Arel_Nodes_NotRegexp o
+        raise NotImplementedError, '!~ not implemented for this db'
+      end
+
       def visit_Arel_Nodes_JoinSource o
         [
           (visit(o.left) if o.left),

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -526,6 +526,26 @@ module Arel
           end
         end
       end
+
+      describe 'Nodes::Regexp' do
+        it 'raises not implemented error' do
+          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo%'))
+
+          assert_raises(NotImplementedError) do
+            @visitor.accept(node)
+          end
+        end
+      end
+
+      describe 'Nodes::NotRegexp' do
+        it 'raises not implemented error' do
+          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo%'))
+
+          assert_raises(NotImplementedError) do
+            @visitor.accept(node)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Didn't add anything to Arel::Predications as I wasn't sure if you'd want to use ~ and !~ or some other method names. Easy to add in any case.
