### PR TITLE
Handle offset on update.

### DIFF
--- a/lib/arel/nodes/update_statement.rb
+++ b/lib/arel/nodes/update_statement.rb
@@ -2,7 +2,7 @@ module Arel
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
       attr_accessor :relation, :wheres, :values, :orders, :limit
-      attr_accessor :key
+      attr_accessor :key, :offset
 
       def initialize
         @relation = nil
@@ -10,6 +10,7 @@ module Arel
         @values   = []
         @orders   = []
         @limit    = nil
+        @offset   = nil
         @key      = nil
       end
 
@@ -20,7 +21,7 @@ module Arel
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @key].hash
+        [@relation, @wheres, @values, @orders, @limit, @key, @offset].hash
       end
 
       def eql? other
@@ -30,6 +31,7 @@ module Arel
           self.values == other.values &&
           self.orders == other.orders &&
           self.limit == other.limit &&
+          self.offset == other.offset &&
           self.key == other.key
       end
       alias :== :eql?

--- a/lib/arel/update_manager.rb
+++ b/lib/arel/update_manager.rb
@@ -24,6 +24,20 @@ module Arel
       self
     end
 
+    def offset
+      @ast.offset && @ast.offset.expr
+    end
+
+    def skip amount
+      if amount
+        @ast.offset = Nodes::Offset.new(amount)
+      else
+        @ast.offset = nil
+      end
+      self
+    end
+    alias :offset= :skip
+
     ###
     # UPDATE +table+
     def table table

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -91,11 +91,12 @@ module Arel
         core.projections = [key]
         stmt.limit       = o.limit
         stmt.orders      = o.orders
+        stmt.offset      = o.offset
         stmt
       end
 
       def visit_Arel_Nodes_UpdateStatement o, collector
-        if o.orders.empty? && o.limit.nil?
+        if o.orders.empty? && o.limit.nil? && o.offset.nil?
           wheres = o.wheres
         else
           wheres = [Nodes::In.new(o.key, [build_subselect(o.key, o)])]

--- a/test/nodes/test_update_statement.rb
+++ b/test/nodes/test_update_statement.rb
@@ -24,6 +24,7 @@ describe Arel::Nodes::UpdateStatement do
       statement1.values   = false
       statement1.orders   = %w[x y z]
       statement1.limit    = 42
+      statement1.offset   = 10
       statement1.key      = 'zomg'
       statement2 = Arel::Nodes::UpdateStatement.new
       statement2.relation = 'zomg'
@@ -31,6 +32,7 @@ describe Arel::Nodes::UpdateStatement do
       statement2.values   = false
       statement2.orders   = %w[x y z]
       statement2.limit    = 42
+      statement2.offset   = 10
       statement2.key      = 'zomg'
       array = [statement1, statement2]
       assert_equal 1, array.uniq.size
@@ -43,6 +45,7 @@ describe Arel::Nodes::UpdateStatement do
       statement1.values   = false
       statement1.orders   = %w[x y z]
       statement1.limit    = 42
+      statement1.offset   = 11
       statement1.key      = 'zomg'
       statement2 = Arel::Nodes::UpdateStatement.new
       statement2.relation = 'zomg'
@@ -50,6 +53,7 @@ describe Arel::Nodes::UpdateStatement do
       statement2.values   = false
       statement2.orders   = %w[x y z]
       statement2.limit    = 42
+      statement2.offset   = 10
       statement2.key      = 'wth'
       array = [statement1, statement2]
       assert_equal 2, array.uniq.size

--- a/test/test_update_manager.rb
+++ b/test/test_update_manager.rb
@@ -26,6 +26,16 @@ module Arel
       assert_match(/LIMIT 10/, um.to_sql)
     end
 
+    it 'handles offset properly' do
+      table = Table.new(:users)
+      um = Arel::UpdateManager.new Table.engine
+      um.key = 'id'
+      um.skip 10
+      um.table table
+      um.set [[table[:name], nil]]
+      assert_match(/OFFSET 10/, um.to_sql)
+    end
+
     describe 'set' do
       it "updates with null" do
         table = Table.new(:users)


### PR DESCRIPTION
Add support to `offset` on update. 

Note that it will not work for MySQL, because it does not support the `offset` clause and subselect (which is the approach for the other adapters) on update.

Related issue on Rails: rails/rails/issues/10849
