### PR TITLE
Add collector argument to address ArgumentError when tested with Oracle

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -74,7 +74,7 @@ module Arel
         collector << " )"
       end
 
-      def visit_Arel_Nodes_UpdateStatement o
+      def visit_Arel_Nodes_UpdateStatement o, collector
         # Oracle does not allow ORDER BY/LIMIT in UPDATEs.
         if o.orders.any? && o.limit.nil?
           # However, there is no harm in silently eating the ORDER BY clause if no LIMIT has been provided,


### PR DESCRIPTION
This pull request addresses following errors when ActiveRecord unit tests executed with Oracle database.

``` ruby
$ cd activerecord
$ rake test_oracle
... snip ...
3927 runs, 9867 assertions, 34 failures, 497 errors, 0 skips
```

One of these test cases is here.

``` ruby
$ ARCONN=oracle ruby -Itest test/cases/xml_serialization_test.rb -n test_should_include_empty_has_many_as_empty_array

  1) Error:
DatabaseConnectedXmlSerializationTest#test_should_include_empty_has_many_as_empty_array:
ArgumentError: wrong number of arguments (2 for 1)
    /home/yahonda/git/arel/lib/arel/visitors/oracle.rb:77:in `visit_Arel_Nodes_UpdateStatement'
    /home/yahonda/git/arel/lib/arel/visitors/reduce.rb:13:in `visit'
    /home/yahonda/git/arel/lib/arel/visitors/reduce.rb:7:in `accept'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:12:in `to_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:109:in `update'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:329:in `update_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:123:in `delete_records'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:258:in `delete_all_with_dependency'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:197:in `delete_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_proxy.rb:442:in `delete_all'
    test/cases/xml_serialization_test.rb:394:in `test_should_include_empty_has_many_as_empty_array'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
2.1.1@railsmaster [ master ~/git/rails/activerecord]$
```

After this commit applied to arel master, ActiveRecord unit test results are 

``` ruby
$ rake test_oracle
3927 runs, 10930 assertions, 19 failures, 39 errors, 0 skips
```
