### PR TITLE
Support to add the casting node to the AST at build time to oracle

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -17,7 +17,7 @@ module Arel
 
         if o.limit && o.offset
           o        = o.dup
-          limit    = o.limit.expr.to_i
+          limit    = o.limit.expr.expr
           offset   = o.offset
           o.offset = nil
           collector << "

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -100,7 +100,7 @@ module Arel
 
           it 'creates a different subquery when there is an offset' do
             stmt = Nodes::SelectStatement.new
-            stmt.limit = Nodes::Limit.new(10)
+            stmt.limit = Nodes::Limit.new(Nodes.build_quoted(10))
             stmt.offset = Nodes::Offset.new(10)
             sql = compile stmt
             sql.must_be_like %{
@@ -115,7 +115,7 @@ module Arel
 
           it 'is idempotent with different subquery' do
             stmt = Nodes::SelectStatement.new
-            stmt.limit = Nodes::Limit.new(10)
+            stmt.limit = Nodes::Limit.new(Nodes.build_quoted(10))
             stmt.offset = Nodes::Offset.new(10)
             sql = compile stmt
             sql2 = compile stmt


### PR DESCRIPTION
This pull request addresses 36 errors when ActiveRecord unit test executed with oracle database.

Since o.limit is Quoted by https://github.com/rails/arel/commit/93d72131bcc24ccb5536bec672d2dac94f8de651 . I have not find other way to "unquote" other than `o.limit.expr.expr`, chaining `expr` method twice is little bit strange (for me).

One of 36 error test case is:

``` ruby
$ cd activerecord
$ ARCONN=oracle ruby -Itest test/cases/relations_test.rb -n test_finding_with_order_limit_and_offset
Using oracle
Run options: -n test_finding_with_order_limit_and_offset --seed 63979

# Running:

E

Finished in 0.925014s, 1.0811 runs/s, 0.0000 assertions/s.

  1) Error:
RelationTest#test_finding_with_order_limit_and_offset:
NoMethodError: undefined method `to_i' for #<Arel::Nodes::Quoted:0x00000004760fa8 @expr=2>
    /home/yahonda/git/arel/lib/arel/visitors/oracle.rb:20:in `visit_Arel_Nodes_SelectStatement'
    /home/yahonda/git/arel/lib/arel/visitors/reduce.rb:13:in `visit'
    /home/yahonda/git/arel/lib/arel/visitors/reduce.rb:7:in `accept'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:12:in `to_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:39:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:613:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:489:in `load'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:233:in `to_a'
    test/cases/relations_test.rb:294:in `test_finding_with_order_limit_and_offset'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
- `rake test_oracle` result without this commit

``` ruby
3930 runs, 10937 assertions, 19 failures, 39 errors, 0 skips
```
- `rake test_oracle` result with this commit

``` ruby
3930 runs, 10994 assertions, 19 failures, 3 errors, 0 skips
```

It would be very appreciated this commit reviewed. Thanks in advance, 
