### PR TITLE
Return self from distinct so it's chainable

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -151,6 +151,7 @@ module Arel
       else
         @ctx.set_quantifier = nil
       end
+      self
     end
 
     def order *expr

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -1073,6 +1073,12 @@ module Arel
         manager.distinct(false)
         manager.ast.cores.last.set_quantifier.must_equal nil
       end
+
+      it "chains" do
+        manager = Arel::SelectManager.new Table.engine
+        manager.distinct.must_equal manager
+        manager.distinct(false).must_equal manager
+      end
     end
   end
 end


### PR DESCRIPTION
The way I'm using this right now is table.project(*some_fields).distinct.where(conditions).join(other_stuff) etc.

Almost all the other methods return self or another chainable expression, but this breaks the chain.

Am I just approaching this wrong?
