### PR TITLE
Remove old FIXME comment

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -86,9 +86,6 @@ module Arel
 
     def from table
       table = Nodes::SqlLiteral.new(table) if String === table
-      # FIXME: this is a hack to support
-      # test_with_two_tables_in_from_without_getting_double_quoted
-      # from the AR tests.
 
       case table
       when Nodes::Join


### PR DESCRIPTION
The comment was introducted on https://github.com/rails/arel/commit/d8de55cee197d887b478b134ec692776613bf998 , and the code has changed.

btw, I could not even find `test_with_two_tables_in_from_without_getting_double_quoted` .

review @rafaelfranca @tenderlove
