### PR TITLE
Add quote_column_name when using Group By

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -446,7 +446,11 @@ module Arel
       end
 
       def visit_Arel_Nodes_Group o, collector
-        collector << quote_column_name(o.expr.to_s)
+        if o.expr.to_s.include?(".")
+          visit o.expr, collector
+        else
+          collector << quote_column_name(o.expr.to_s)
+        end
       end
 
       def visit_Arel_Nodes_NamedFunction o, collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -446,7 +446,7 @@ module Arel
       end
 
       def visit_Arel_Nodes_Group o, collector
-        visit o.expr, collector
+        collector << quote_column_name(o.expr.to_s)
       end
 
       def visit_Arel_Nodes_NamedFunction o, collector

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -46,7 +46,7 @@ module Arel
           manager = Arel::SelectManager.new Table.engine
           manager.from table
           manager.group :foo
-          manager.to_sql.must_be_like %{ SELECT FROM "users" GROUP BY foo }
+          manager.to_sql.must_be_like %{ SELECT FROM "users" GROUP BY "foo" }
         end
       end
 
@@ -655,7 +655,7 @@ module Arel
         manager = Arel::SelectManager.new Table.engine
         manager.from table
         manager.group 'foo'
-        manager.to_sql.must_be_like %{ SELECT FROM "users" GROUP BY foo }
+        manager.to_sql.must_be_like %{ SELECT FROM "users" GROUP BY "foo" }
       end
     end
 


### PR DESCRIPTION
This fixes [rails/rails#15008](https://github.com/rails/rails/issues/15008). 
It seems that when using `ActiveRecord::QueryMethods.group()`, column name never be quoted.