### PR TITLE
Added update and delete convenience methods

### DIFF
--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -104,6 +104,14 @@ primary_key (#{caller.first}) is deprecated and will be removed in Arel 4.0.0
       InsertManager.new(@engine)
     end
 
+    def update_manager
+      UpdateManager.new(@engine)
+    end
+
+    def delete_manager
+      DeleteManager.new(@engine)
+    end
+
     def hash
       # Perf note: aliases, table alias and engine is excluded from the hash
       #  aliases can have a loop back to this table breaking hashes in parent

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -67,6 +67,22 @@ module Arel
       end
     end
 
+    describe 'update_manager' do
+      it 'should return an update manager' do
+        um = @relation.update_manager
+        assert_kind_of Arel::UpdateManager, um
+        assert_equal um.engine, @relation.engine
+      end
+    end
+
+    describe 'delete_manager' do
+      it 'should return a delete manager' do
+        dm = @relation.delete_manager
+        assert_kind_of Arel::DeleteManager, dm
+        assert_equal dm.engine, @relation.engine
+      end
+    end
+
     describe 'having' do
       it 'adds a having clause' do
         mgr = @relation.having @relation[:id].eq(10)


### PR DESCRIPTION
It seems to make sense to have all the engine-injected managers in one place.
