### PR TITLE
Fix typo `delegte` => `delegate`

### DIFF
--- a/lib/arel/visitors/bind_substitute.rb
+++ b/lib/arel/visitors/bind_substitute.rb
@@ -1,7 +1,7 @@
 module Arel
   module Visitors
     class BindSubstitute
-      def initialize delegte
+      def initialize delegate
         @delegate = delegate
       end
     end


### PR DESCRIPTION
I don't see `BindSubstitute` being used now, but this was wrong.
