### PR TITLE
Wrap nested Nodes::Grouping in brackets only once

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -429,8 +429,12 @@ module Arel
       end
 
       def visit_Arel_Nodes_Grouping o, collector
-        collector << "("
-        visit(o.expr, collector) << ")"
+        if o.expr.is_a? Nodes::Grouping
+          visit(o.expr, collector)
+        else
+          collector << "("
+          visit(o.expr, collector) << ")"
+        end
       end
 
       def visit_Arel_SelectManager o, collector

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -131,6 +131,13 @@ module Arel
         end
       end
 
+      describe 'Nodes::Grouping' do
+        it 'wraps nested groupings in brackets only once' do
+          sql = compile Nodes::Grouping.new(Nodes::Grouping.new(Nodes.build_quoted('foo')))
+          sql.must_equal "('foo')"
+        end
+      end
+
       describe 'Nodes::NotEqual' do
         it 'should handle false' do
           val = Nodes.build_quoted(false, @table[:active])


### PR DESCRIPTION
Tested on Rails 4.1 application with mysql2.  

``` ruby
# Before:
Developer.where(id: [1,nil])  
# SELECT `developers`.* FROM `developers`  WHERE ((`developers`.`id` = 1 OR `developers`.`id` IS NULL))  

# After:  
Developer.where(id: [1,nil])  
# SELECT `developers`.* FROM `developers`  WHERE (`developers`.`id` = 1 OR `developers`.`id` IS NULL)


# Unfortunately, there are still extra brackets in the following queries, but I'm tired debugging Arel
# Notice 2 spaces before WHERE as well
Developer.where.not(id: [1,2])  
# SELECT `developers`.* FROM `developers`  WHERE (`developers`.`id` NOT IN (1, 2))
Developer.where.not(id: [1,nil]) 
#  SELECT `developers`.* FROM `developers`  WHERE (NOT ((`developers`.`id` = 1 OR `developers`.`id` IS NULL)))
```
