### PR TITLE
Type cast value before quoting if we have a column

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -751,6 +751,9 @@ module Arel
 
       def quote value, column = nil
         return value if Arel::Nodes::SqlLiteral === value
+        if column
+          value = column.type_cast_for_database(value)
+        end
         @connection.quote value, column
       end
 

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -1,5 +1,8 @@
 module FakeRecord
   class Column < Struct.new(:name, :type)
+    def type_cast_for_database(value)
+      value
+    end
   end
 
   class Connection


### PR DESCRIPTION
Active Record is being refactored towards having the `quote` method care
only about types, and not about the column. This assumes that any column
specific behavior will have been handled before passing the value to
`quote`.
