### PR TITLE
Fix warning

### DIFF
--- a/test/nodes/test_infix_operation.rb
+++ b/test/nodes/test_infix_operation.rb
@@ -18,7 +18,7 @@ module Arel
         assert_equal 'zomg', aliaz.right
       end
 
-      def test_opertaion_ordering
+      def test_operation_ordering
         operation = InfixOperation.new :+, 1, 2
         ordering = operation.desc
         assert_kind_of Descending, ordering

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -249,7 +249,7 @@ module Arel
 
       it "unsupported input should not raise ArgumentError" do
         error = assert_raises(RuntimeError) { compile(nil) }
-        assert_match /\Aunsupported/, error.message
+        assert_match(/\Aunsupported/, error.message)
       end
 
       it "should visit_Arel_SelectManager, which is a subquery" do


### PR DESCRIPTION
- Fix ambiguous argument warning
- Fix typo: `test_opertaion_ordering` =>  `test_operation_ordering`
