### PR TITLE
Remove use of  `.blank?`

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -106,7 +106,7 @@ module Arel
 
       case relation
       when String, Nodes::SqlLiteral
-        raise if relation.blank?
+        raise if relation.empty?
         klass = Nodes::StringJoin
       end
 

--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -57,7 +57,7 @@ primary_key (#{caller.first}) is deprecated and will be removed in Arel 4.0.0
 
       case relation
       when String, Nodes::SqlLiteral
-        raise if relation.blank?
+        raise if relation.empty?
         klass = Nodes::StringJoin
       end
 


### PR DESCRIPTION
Arel doesn't depend on activesupport and doesn't have "String#blank?"
Remove usage of `.blank?` to match empty strings with a regular expression instead.
