### PR TITLE
Add Regexp and NotRegexp support for MySQL.

### DIFF
--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -77,6 +77,13 @@ module Arel
         end
       end
 
+      def visit_Arel_Nodes_Regexp o, collector
+        infix_value o, collector, ' REGEXP '
+      end
+
+      def visit_Arel_Nodes_NotRegexp o, collector
+        infix_value o, collector, ' NOT REGEXP '
+      end
     end
   end
 end


### PR DESCRIPTION
Code shamelessly stolen from https://github.com/rails/arel/commit/6296617c159d5cee0ba1c76f4ea983e3b5e26b6b
