### PR TITLE
adding the FROM to postgreSQL UPDATE with inner joins related to #111

### DIFF
--- a/lib/arel/nodes/update_statement.rb
+++ b/lib/arel/nodes/update_statement.rb
@@ -1,10 +1,12 @@
 module Arel
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
+      attr_accessor :cores
       attr_accessor :relation, :wheres, :values, :orders, :limit
       attr_accessor :key
 
-      def initialize
+      def initialize cores = [SelectCore.new]
+        @cores    = cores
         @relation = nil
         @wheres   = []
         @values   = []
@@ -15,16 +17,18 @@ module Arel
 
       def initialize_copy other
         super
+        @cores  = @cores.map { |x| x.clone }
         @wheres = @wheres.clone
         @values = @values.clone
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @key].hash
+        [@cores, @relation, @wheres, @values, @orders, @limit, @key].hash
       end
 
       def eql? other
         self.class == other.class &&
+          self.cores == other.cores &&
           self.relation == other.relation &&
           self.wheres == other.wheres &&
           self.values == other.values &&

--- a/lib/arel/update_manager.rb
+++ b/lib/arel/update_manager.rb
@@ -1,9 +1,10 @@
 module Arel
   class UpdateManager < Arel::TreeManager
-    def initialize engine
-      super
+    def initialize engine, table = nil
+      super(engine)
       @ast = Nodes::UpdateStatement.new
-      @ctx = @ast
+      @ctx    = @ast.cores.last
+      from table
     end
 
     def take limit
@@ -37,6 +38,19 @@ module Arel
 
     def where expr
       @ast.wheres << expr
+      self
+    end
+
+    def from table
+      table = Nodes::SqlLiteral.new(table) if String === table
+
+      case table
+      when Nodes::Join
+        @ctx.source.right << table
+      else
+        @ctx.source.left = table
+      end
+
       self
     end
 

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -23,6 +23,40 @@ module Arel
         collector << "DISTINCT ON ( "
         visit(o.expr, collector) << " )"
       end
+
+      def visit_Arel_Nodes_UpdateStatement o, collector
+        if o.orders.empty? && o.limit.nil?
+          wheres = o.wheres
+        else
+          wheres = [Nodes::In.new(o.key, [build_subselect(o.key, o)])]
+        end
+
+        collector << "UPDATE "
+
+        if o.relation.right && o.relation.right.first.instance_of?(Arel::Nodes::InnerJoin) && o.cores.first.source.empty?
+          o.cores = o.relation
+          collector = visit o.relation.left, collector
+        else
+          collector = visit o.relation, collector
+        end
+
+        unless o.values.empty?
+          collector << " SET "
+          collector = inject_join o.values, collector, ", "
+        end
+
+        unless o.cores.empty? && o.cores.right.empty?
+          collector << " FROM "
+          collector = visit o.cores.right.first.left, collector
+        end
+
+        unless wheres.empty?
+          collector << " WHERE "
+          collector = inject_join wheres, collector, " AND "
+        end
+
+        collector
+      end
     end
   end
 end


### PR DESCRIPTION
This fix is to include FROM to UPDATE statement and UpdateManager in order to support Updates that perform columnA = columnB like described here in a Rails issue https://github.com/rails/rails/issues/13496 and I was trying to fix with String manipulation here https://github.com/rails/rails/pull/15631

Also related to #111

I'd like to have some feedback to polish the code, thanks!

cc @rafaelfranca
