### PR TITLE
Fix named functions within subqueries

### DIFF
--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -4,12 +4,12 @@ module Arel
       private
 
       def visit_Arel_Nodes_Matches o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} ILIKE #{visit o.right, a}"
       end
 
       def visit_Arel_Nodes_DoesNotMatch o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} NOT ILIKE #{visit o.right, a}"
       end
 

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -604,9 +604,12 @@ module Arel
 
       def fetch_attribute object, attribute
         case object
-        when Arel::Attributes::Attribute; object
-        when Arel::Nodes::NamedFunction; nil
-        else attribute
+        when Arel::Attributes::Attribute
+          object
+        when Arel::Nodes::NamedFunction
+          nil
+        else
+          attribute
         end
       end
     end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -400,37 +400,37 @@ module Arel
       end
 
       def visit_Arel_Nodes_Between o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} BETWEEN #{visit o.right, a}"
       end
 
       def visit_Arel_Nodes_GreaterThanOrEqual o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} >= #{visit o.right, a}"
       end
 
       def visit_Arel_Nodes_GreaterThan o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} > #{visit o.right, a}"
       end
 
       def visit_Arel_Nodes_LessThanOrEqual o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} <= #{visit o.right, a}"
       end
 
       def visit_Arel_Nodes_LessThan o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} < #{visit o.right, a}"
       end
 
       def visit_Arel_Nodes_Matches o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} LIKE #{visit o.right, a}"
       end
 
       def visit_Arel_Nodes_DoesNotMatch o, a
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         "#{visit o.left, a} NOT LIKE #{visit o.right, a}"
       end
 
@@ -478,7 +478,7 @@ module Arel
         if Array === o.right && o.right.empty?
           '1=0'
         else
-          a = o.left if Arel::Attributes::Attribute === o.left
+          a = fetch_attribute o.left, a
           "#{visit o.left, a} IN (#{visit o.right, a})"
         end
       end
@@ -487,7 +487,7 @@ module Arel
         if Array === o.right && o.right.empty?
           '1=1'
         else
-          a = o.left if Arel::Attributes::Attribute === o.left
+          a = fetch_attribute o.left, a
           "#{visit o.left, a} NOT IN (#{visit o.right, a})"
         end
       end
@@ -508,7 +508,7 @@ module Arel
       def visit_Arel_Nodes_Equality o, a
         right = o.right
 
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         if right.nil?
           "#{visit o.left, a} IS NULL"
         else
@@ -519,7 +519,7 @@ module Arel
       def visit_Arel_Nodes_NotEqual o, a
         right = o.right
 
-        a = o.left if Arel::Attributes::Attribute === o.left
+        a = fetch_attribute o.left, a
         if right.nil?
           "#{visit o.left, a} IS NOT NULL"
         else
@@ -598,6 +598,16 @@ module Arel
 
       def quote_column_name name
         @quoted_columns[name] ||= Arel::Nodes::SqlLiteral === name ? name : @connection.quote_column_name(name)
+      end
+
+      private
+
+      def fetch_attribute object, attribute
+        case object
+        when Arel::Attributes::Attribute; object
+        when Arel::Nodes::NamedFunction; nil
+        else attribute
+        end
       end
     end
   end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -48,6 +48,14 @@ module Arel
         sql.must_be_like %{ omg(*) = 2 }
       end
 
+      it 'should handle named functions within subqueries' do
+        users = Table.new(:users)
+        products = Table.new(:products)
+        node = products.project(products[:id]).where(products[:id].in(users.project(users[:id]).where(users[:name].lower.eq('foo'))))
+        sql = @visitor.accept(node)
+        sql.must_match %r{LOWER\(\"users\".\"name\"\) = 'foo'}
+      end
+
       it 'should visit built-in functions' do
         function = Nodes::Count.new([Arel.star])
         assert_equal 'COUNT(*)', @visitor.accept(function)


### PR DESCRIPTION
Arel is currently casting values compared against NamedFunctions improperly. 

Using tables from the test suite, the statement

    products.project(products[:id]).where(products[:id].in(users.project(users[:id]).where(users[:name].lower.eq('foo')))) 

currently generates

    (SELECT \"products\".\"id\" FROM \"products\"  WHERE \"products\".\"id\" IN (SELECT \"users\".\"id\" FROM \"users\"  WHERE LOWER(\"users\".\"name\") = 0))

With these changes, it properly generates

    (SELECT \"products\".\"id\" FROM \"products\"  WHERE \"products\".\"id\" IN (SELECT \"users\".\"id\" FROM \"users\"  WHERE LOWER(\"users\".\"name\") = 'foo'))