### PR TITLE
Add SelectManager#distinct_on to set/unset Arel::Nodes::DistinctOn quantifier

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -155,6 +155,15 @@ module Arel
       self
     end
 
+    def distinct_on(value)
+      if value
+        @ctx.set_quantifier = Arel::Nodes::DistinctOn.new(value)
+      else
+        @ctx.set_quantifier = nil
+      end
+      self
+    end
+
     def order *expr
       # FIXME: We SHOULD NOT be converting these to SqlLiteral automatically
       @ast.orders.concat expr.map { |x|

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -1158,5 +1158,26 @@ module Arel
         manager.distinct(false).must_equal manager
       end
     end
+
+    describe 'distinct_on' do
+      it 'sets the quantifier' do
+        manager = Arel::SelectManager.new Table.engine
+        table = Table.new :users
+
+        manager.distinct_on(table['id'])
+        manager.ast.cores.last.set_quantifier.must_equal Arel::Nodes::DistinctOn.new(table['id'])
+
+        manager.distinct_on(false)
+        manager.ast.cores.last.set_quantifier.must_equal nil
+      end
+
+      it "chains" do
+        manager = Arel::SelectManager.new Table.engine
+        table = Table.new :users
+
+        manager.distinct_on(table['id']).must_equal manager
+        manager.distinct_on(false).must_equal manager
+      end
+    end
   end
 end


### PR DESCRIPTION
This makes it easier to use DISTINCT ON:

``` ruby
table = Arel::Table.new(:users)
table.project(Arel.star).distinct_on(table[:id]).to_sql
# => "SELECT DISTINCT ON ( \"users\".\"id\" ) * FROM \"users\""
```

Resolves #302 
