### PR TITLE
Fixed for nested arrays given to SQL IN

### DIFF
--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -80,6 +80,8 @@ module Arel
       case other
       when Arel::Nodes::Node, Arel::Attributes::Attribute, Arel::Table, Arel::Nodes::BindParam, Arel::SelectManager
         other
+      when Array
+        other.map { |item| build_quoted(item, attribute) }
       else
         case attribute
         when Arel::Attributes::Attribute

--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -523,6 +523,14 @@ module Arel
             SELECT "users"."id" FROM "users" WHERE "users"."id" IN (1, 2, 3)
           }
         end
+        it 'should generate IN in sql for nested arrays' do
+          relation = Table.new(:users)
+          mgr = relation.project relation[:id]
+          mgr.where relation[:id].in([[[1]],[2],3])
+          mgr.to_sql.must_be_like %{
+            SELECT "users"."id" FROM "users" WHERE "users"."id" IN (1, 2, 3)
+          }
+        end
       end
 
       describe '#in_any' do


### PR DESCRIPTION
This was reported first at https://github.com/rails/rails/issues/16580 but from my digging it seems it's a behaviour change in arel 6. Not sure if this should be fixed in rails (https://github.com/rails/rails/pull/16805) or in arel.

To be more clear:

``` ruby
#arel 5
> User.arel_table[:id].in([[1],2,3]).to_sql
 => "users"."id" IN (1, 2, 3)

#arel 6
> User.arel_table[:id].in([[1],2,3]).to_sql
 "users"."id" IN (NULL, 2, 3)
```

/cc @tenderlove 
