### PR TITLE
BACKPORT: `Extract#as` should not mutate the receiver

### DIFF
--- a/lib/arel/nodes/extract.rb
+++ b/lib/arel/nodes/extract.rb
@@ -3,20 +3,14 @@ module Arel
 
     class Extract < Arel::Nodes::Unary
       include Arel::Expression
+      include Arel::AliasPredication
       include Arel::Predications
 
       attr_accessor :field
-      attr_accessor :alias
 
-      def initialize expr, field, aliaz = nil
+      def initialize expr, field
         super(expr)
         @field = field
-        @alias = aliaz && SqlLiteral.new(aliaz)
-      end
-
-      def as aliaz
-        self.alias = SqlLiteral.new(aliaz)
-        self
       end
 
       def hash
@@ -25,8 +19,7 @@ module Arel
 
       def eql? other
         super &&
-          self.field == other.field &&
-          self.alias == other.alias
+          self.field == other.field
       end
       alias :== :eql?
     end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -366,7 +366,7 @@ module Arel
       end
 
       def visit_Arel_Nodes_Extract o, a
-        "EXTRACT(#{o.field.to_s.upcase} FROM #{visit o.expr, a})#{o.alias ? " AS #{visit o.alias, a}" : ''}"
+        "EXTRACT(#{o.field.to_s.upcase} FROM #{visit o.expr, a})"
       end
 
       def visit_Arel_Nodes_Count o, a

--- a/test/nodes/test_extract.rb
+++ b/test/nodes/test_extract.rb
@@ -15,6 +15,14 @@ describe Arel::Nodes::Extract do
         EXTRACT(DATE FROM "users"."timestamp") AS foo
       }
     end
+
+    it 'should not mutate the extract' do
+      table = Arel::Table.new :users
+      extract = table[:timestamp].extract('date')
+      before = extract.dup
+      extract.as('foo')
+      assert_equal extract, before
+    end
   end
 
   describe 'equality' do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/16913
