### PR TITLE
Remove requiring arel/collectors/sql_string

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -1,5 +1,3 @@
-require 'arel/collectors/sql_string'
-
 module Arel
   class SelectManager < Arel::TreeManager
     include Arel::Crud


### PR DESCRIPTION
- It is already required in lib/arel/tree_manager.rb and SelectManager
  inherits from TreeManager