### PR TITLE
Reuse `maybe_visit` method

### DIFF
--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -69,12 +69,7 @@ module Arel
           collector = inject_join o.orders, collector, ', '
         end
 
-        if o.limit
-          collector << " "
-          visit(o.limit, collector)
-        else
-          collector
-        end
+        maybe_visit o.limit, collector
       end
 
     end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -229,15 +229,9 @@ module Arel
       def visit_Arel_Nodes_SelectCore o, collector
         collector << "SELECT"
 
-        if o.top
-          collector << " "
-          collector = visit o.top, collector
-        end
+        maybe_visit o.top, collector
 
-        if o.set_quantifier
-          collector << " "
-          collector = visit o.set_quantifier, collector
-        end
+        maybe_visit o.set_quantifier, collector
 
         unless o.projections.empty?
           collector << SPACE
@@ -271,10 +265,7 @@ module Arel
           end
         end
 
-        if o.having
-          collector << " "
-          collector = visit(o.having, collector)
-        end
+        maybe_visit o.having, collector
 
         unless o.windows.empty?
           collector << WINDOW


### PR DESCRIPTION
This commit simply removes duplicated code by reusing the [existing `maybe_visit` method](https://github.com/rails/arel/blob/master/lib/arel/visitors/to_sql.rb#L786).
