### PR TITLE
Completes 08e6491 in reusing `maybe_visit`

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -229,9 +229,9 @@ module Arel
       def visit_Arel_Nodes_SelectCore o, collector
         collector << "SELECT"
 
-        maybe_visit o.top, collector
+        collector = maybe_visit o.top, collector
 
-        maybe_visit o.set_quantifier, collector
+        collector = maybe_visit o.set_quantifier, collector
 
         unless o.projections.empty?
           collector << SPACE
@@ -265,7 +265,7 @@ module Arel
           end
         end
 
-        maybe_visit o.having, collector
+        collector = maybe_visit o.having, collector
 
         unless o.windows.empty?
           collector << WINDOW


### PR DESCRIPTION
:sweat: I don't know why the tests did not fail, but to keep the same syntax as before 08e6491, `collector =` is required.

Maybe `visit` changes `collector` in-place, so the result is the same, but since I'm not sure about the side effects, I think this PR is needed too. Sorry! :sweat:
