### PR TITLE
Bump warning

### DIFF
--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -32,7 +32,7 @@ module Arel
     def primary_key
       if $VERBOSE
         warn <<-eowarn
-primary_key (#{caller.first}) is deprecated and will be removed in Arel 4.0.0
+primary_key (#{caller.first}) is deprecated and will be removed.
         eowarn
       end
       @primary_key ||= begin


### PR DESCRIPTION
Its 6.0, and we haven't yet gotten rid of this warning. Bump warning to 6.0.0 for now.