### PR TITLE
`#not_in` with a range should respect proper precedence

### DIFF
--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -83,7 +83,7 @@ module Arel
           else
             right = Nodes::GreaterThan.new(self, Nodes.build_quoted(other.end, self))
           end
-          Nodes::Or.new left, right
+          left.or(right)
         end
       when Array
         Nodes::NotIn.new self, other.map { |x| Nodes.build_quoted(x, self) }

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -480,16 +480,16 @@ module Arel
 
         it 'can handle two dot ranges' do
           node = @attr.not_in 1..3
-          compile(node).must_be_like %{
-            "users"."id" < 1 OR "users"."id" > 3
-          }
+          compile(node).must_equal(
+            %{("users"."id" < 1 OR "users"."id" > 3)}
+          )
         end
 
         it 'can handle three dot ranges' do
           node = @attr.not_in 1...3
-          compile(node).must_be_like %{
-            "users"."id" < 1 OR "users"."id" >= 3
-          }
+          compile(node).must_equal(
+            %{("users"."id" < 1 OR "users"."id" >= 3)}
+          )
         end
 
         it 'can handle ranges bounded by infinity' do


### PR DESCRIPTION
Currently, doing

``` ruby
relation[:id].not_eq(4).and(relation[:id].not_in(1..3))
```

will generate

``` sql
"id" != 4 AND "id" < 1 OR "id" > 3
```

Which would incorrectly include records with an id of 4, as the OR
statement has higher precidence than the AND statement. The `or`
method on `Node` properly groups the statement in parenthesis.
