### PR TITLE
Deprecate passing ranges to `#in` and `#not_in`

### DIFF
--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -548,6 +548,74 @@ module Arel
         end
       end
 
+      describe 'with a range' do
+        it 'can be constructed with a standard range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(1..3)
+
+          node.must_equal Nodes::Between.new(
+            attribute,
+            Nodes::And.new([
+              Nodes::Casted.new(1, attribute),
+              Nodes::Casted.new(3, attribute)
+            ])
+          )
+        end
+
+        it 'can be constructed with a range starting from -Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(-::Float::INFINITY..3)
+
+          node.must_equal Nodes::LessThanOrEqual.new(
+            attribute,
+            Nodes::Casted.new(3, attribute)
+          )
+        end
+
+        it 'can be constructed with an exclusive range starting from -Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(-::Float::INFINITY...3)
+
+          node.must_equal Nodes::LessThan.new(
+            attribute,
+            Nodes::Casted.new(3, attribute)
+          )
+        end
+
+        it 'can be constructed with an infinite range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(-::Float::INFINITY..::Float::INFINITY)
+
+          node.must_equal Nodes::NotIn.new(attribute, [])
+        end
+
+        it 'can be constructed with a range ending at Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(0..::Float::INFINITY)
+
+          node.must_equal Nodes::GreaterThanOrEqual.new(
+            attribute,
+            Nodes::Casted.new(0, attribute)
+          )
+        end
+
+        it 'can be constructed with an exclusive range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(0...3)
+
+          node.must_equal Nodes::And.new([
+            Nodes::GreaterThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            ),
+            Nodes::LessThan.new(
+              attribute,
+              Nodes::Casted.new(3, attribute)
+            )
+          ])
+        end
+      end
+
       describe '#in' do
         it 'can be constructed with a subquery' do
           relation = Table.new(:users)
@@ -558,74 +626,6 @@ module Arel
           node = attribute.in(mgr)
 
           node.must_equal Nodes::In.new(attribute, mgr.ast)
-        end
-
-        describe 'with a range' do
-          it 'can be constructed with a standard range' do
-            attribute = Attribute.new nil, nil
-            node = attribute.in(1..3)
-
-            node.must_equal Nodes::Between.new(
-              attribute,
-              Nodes::And.new([
-                Nodes::Casted.new(1, attribute),
-                Nodes::Casted.new(3, attribute)
-              ])
-            )
-          end
-
-          it 'can be constructed with a range starting from -Infinity' do
-            attribute = Attribute.new nil, nil
-            node = attribute.in(-::Float::INFINITY..3)
-
-            node.must_equal Nodes::LessThanOrEqual.new(
-              attribute,
-              Nodes::Casted.new(3, attribute)
-            )
-          end
-
-          it 'can be constructed with an exclusive range starting from -Infinity' do
-            attribute = Attribute.new nil, nil
-            node = attribute.in(-::Float::INFINITY...3)
-
-            node.must_equal Nodes::LessThan.new(
-              attribute,
-              Nodes::Casted.new(3, attribute)
-            )
-          end
-
-          it 'can be constructed with an infinite range' do
-            attribute = Attribute.new nil, nil
-            node = attribute.in(-::Float::INFINITY..::Float::INFINITY)
-
-            node.must_equal Nodes::NotIn.new(attribute, [])
-          end
-
-          it 'can be constructed with a range ending at Infinity' do
-            attribute = Attribute.new nil, nil
-            node = attribute.in(0..::Float::INFINITY)
-
-            node.must_equal Nodes::GreaterThanOrEqual.new(
-              attribute,
-              Nodes::Casted.new(0, attribute)
-            )
-          end
-
-          it 'can be constructed with an exclusive range' do
-            attribute = Attribute.new nil, nil
-            node = attribute.in(0...3)
-
-            node.must_equal Nodes::And.new([
-              Nodes::GreaterThanOrEqual.new(
-                attribute,
-                Nodes::Casted.new(0, attribute)
-              ),
-              Nodes::LessThan.new(
-                attribute,
-                Nodes::Casted.new(3, attribute)
-              )
-            ])
-          end
         end
 
         it 'can be constructed with a list' do
@@ -695,6 +695,77 @@ module Arel
         end
       end
 
+      describe 'with a range' do
+        it 'can be constructed with a standard range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(1..3)
+
+          node.must_equal Nodes::Grouping.new(Nodes::Or.new(
+            Nodes::LessThan.new(
+              attribute,
+              Nodes::Casted.new(1, attribute)
+            ),
+            Nodes::GreaterThan.new(
+              attribute,
+              Nodes::Casted.new(3, attribute)
+            )
+          ))
+        end
+
+        it 'can be constructed with a range starting from -Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(-::Float::INFINITY..3)
+
+          node.must_equal Nodes::GreaterThan.new(
+            attribute,
+            Nodes::Casted.new(3, attribute)
+          )
+        end
+
+        it 'can be constructed with an exclusive range starting from -Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(-::Float::INFINITY...3)
+
+          node.must_equal Nodes::GreaterThanOrEqual.new(
+            attribute,
+            Nodes::Casted.new(3, attribute)
+          )
+        end
+
+        it 'can be constructed with an infinite range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(-::Float::INFINITY..::Float::INFINITY)
+
+          node.must_equal Nodes::In.new(attribute, [])
+        end
+
+        it 'can be constructed with a range ending at Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(0..::Float::INFINITY)
+
+          node.must_equal Nodes::LessThan.new(
+            attribute,
+            Nodes::Casted.new(0, attribute)
+          )
+        end
+
+        it 'can be constructed with an exclusive range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(0...3)
+
+          node.must_equal Nodes::Grouping.new(Nodes::Or.new(
+            Nodes::LessThan.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            ),
+            Nodes::GreaterThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(3, attribute)
+            )
+          ))
+        end
+      end
+
       describe '#not_in' do
         it 'can be constructed with a subquery' do
           relation = Table.new(:users)
@@ -705,77 +776,6 @@ module Arel
           node = attribute.not_in(mgr)
 
           node.must_equal Nodes::NotIn.new(attribute, mgr.ast)
-        end
-
-        describe 'with a range' do
-          it 'can be constructed with a standard range' do
-            attribute = Attribute.new nil, nil
-            node = attribute.not_in(1..3)
-
-            node.must_equal Nodes::Grouping.new(Nodes::Or.new(
-              Nodes::LessThan.new(
-                attribute,
-                Nodes::Casted.new(1, attribute)
-              ),
-              Nodes::GreaterThan.new(
-                attribute,
-                Nodes::Casted.new(3, attribute)
-              )
-            ))
-          end
-
-          it 'can be constructed with a range starting from -Infinity' do
-            attribute = Attribute.new nil, nil
-            node = attribute.not_in(-::Float::INFINITY..3)
-
-            node.must_equal Nodes::GreaterThan.new(
-              attribute,
-              Nodes::Casted.new(3, attribute)
-            )
-          end
-
-          it 'can be constructed with an exclusive range starting from -Infinity' do
-            attribute = Attribute.new nil, nil
-            node = attribute.not_in(-::Float::INFINITY...3)
-
-            node.must_equal Nodes::GreaterThanOrEqual.new(
-              attribute,
-              Nodes::Casted.new(3, attribute)
-            )
-          end
-
-          it 'can be constructed with an infinite range' do
-            attribute = Attribute.new nil, nil
-            node = attribute.not_in(-::Float::INFINITY..::Float::INFINITY)
-
-            node.must_equal Nodes::In.new(attribute, [])
-          end
-
-          it 'can be constructed with a range ending at Infinity' do
-            attribute = Attribute.new nil, nil
-            node = attribute.not_in(0..::Float::INFINITY)
-
-            node.must_equal Nodes::LessThan.new(
-              attribute,
-              Nodes::Casted.new(0, attribute)
-            )
-          end
-
-          it 'can be constructed with an exclusive range' do
-            attribute = Attribute.new nil, nil
-            node = attribute.not_in(0...3)
-
-            node.must_equal Nodes::Grouping.new(Nodes::Or.new(
-              Nodes::LessThan.new(
-                attribute,
-                Nodes::Casted.new(0, attribute)
-              ),
-              Nodes::GreaterThanOrEqual.new(
-                attribute,
-                Nodes::Casted.new(3, attribute)
-              )
-            ))
-          end
         end
 
         it 'can be constructed with a list' do

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -307,13 +307,11 @@ module Arel
         table = Table.new :users
         @m1 = Arel::SelectManager.new Table.engine, table
         @m1.project Arel.star
-        @m1.where(table[:age].in(18..60))
+        @m1.where(table[:age].between(18..60))
 
         @m2 = Arel::SelectManager.new Table.engine, table
         @m2.project Arel.star
-        @m2.where(table[:age].in(40..99))
-
-
+        @m2.where(table[:age].between(40..99))
       end
 
       it 'should except two managers' do

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -375,33 +375,33 @@ module Arel
         end
 
         it 'can handle two dot ranges' do
-          node = @attr.in 1..3
+          node = @attr.between 1..3
           compile(node).must_be_like %{
             "users"."id" BETWEEN 1 AND 3
           }
         end
 
         it 'can handle three dot ranges' do
-          node = @attr.in 1...3
+          node = @attr.between 1...3
           compile(node).must_be_like %{
             "users"."id" >= 1 AND "users"."id" < 3
           }
         end
 
         it 'can handle ranges bounded by infinity' do
-          node = @attr.in 1..Float::INFINITY
+          node = @attr.between 1..Float::INFINITY
           compile(node).must_be_like %{
             "users"."id" >= 1
           }
-          node = @attr.in(-Float::INFINITY..3)
+          node = @attr.between(-Float::INFINITY..3)
           compile(node).must_be_like %{
             "users"."id" <= 3
           }
-          node = @attr.in(-Float::INFINITY...3)
+          node = @attr.between(-Float::INFINITY...3)
           compile(node).must_be_like %{
             "users"."id" < 3
           }
-          node = @attr.in(-Float::INFINITY..Float::INFINITY)
+          node = @attr.between(-Float::INFINITY..Float::INFINITY)
           compile(node).must_be_like %{1=1}
         end
 
@@ -479,33 +479,33 @@ module Arel
         end
 
         it 'can handle two dot ranges' do
-          node = @attr.not_in 1..3
+          node = @attr.not_between 1..3
           compile(node).must_equal(
             %{("users"."id" < 1 OR "users"."id" > 3)}
           )
         end
 
         it 'can handle three dot ranges' do
-          node = @attr.not_in 1...3
+          node = @attr.not_between 1...3
           compile(node).must_equal(
             %{("users"."id" < 1 OR "users"."id" >= 3)}
           )
         end
 
         it 'can handle ranges bounded by infinity' do
-          node = @attr.not_in 1..Float::INFINITY
+          node = @attr.not_between 1..Float::INFINITY
           compile(node).must_be_like %{
             "users"."id" < 1
           }
-          node = @attr.not_in(-Float::INFINITY..3)
+          node = @attr.not_between(-Float::INFINITY..3)
           compile(node).must_be_like %{
             "users"."id" > 3
           }
-          node = @attr.not_in(-Float::INFINITY...3)
+          node = @attr.not_between(-Float::INFINITY...3)
           compile(node).must_be_like %{
             "users"."id" >= 3
           }
-          node = @attr.not_in(-Float::INFINITY..Float::INFINITY)
+          node = @attr.not_between(-Float::INFINITY..Float::INFINITY)
           compile(node).must_be_like %{1=0}
         end
 


### PR DESCRIPTION
The goal of these methods should be to generate in nodes, not handle
every possible permutation of more than one value. The `#between` and
`#not_between` methods have been extracted, which better represent the
semantics of handling ranges in SQL.

/cc @tenderlove 
