### PR TITLE
NameError: undefined local variable or method 'visit_Arel_Nodes_Quoted'

### DIFF
--- a/lib/arel/visitors/visitor.rb
+++ b/lib/arel/visitors/visitor.rb
@@ -27,7 +27,7 @@ module Arel
 
       def visit object
         send dispatch[object.class.name], object
-      rescue NoMethodError => e
+      rescue NameError => e
         raise e if respond_to?(dispatch[object.class.name], true)
         superklass = object.class.ancestors.find { |klass|
           respond_to?(dispatch[klass.name], true)


### PR DESCRIPTION
Hello,

A few of my coworkers and I are getting strange exceptions from `arel`. I haven't been able to determine exactly why the errors are occurring, or the specific conditions under which they occur, but rescuing from `NameError` instead of `NoMethodError` in `lib/arel/visitors/visitor.rb` seems to fix the problem entirely.

For what it's worth, it seems that the problem originates which any call to `ActiveRecord::FinderMethods#exists?`--if I remove the call in my `generate_unique.rb` file, the error just happens later when rails does a `uniqueness` validation.

I'm including the backtrace from the exception, and a few additional details in the hopes that you all will be able to make more sense of the error than I can.
- So far, I've been able to reproduce the error with 6.0.0.beta1 and 6.0.0.beta2, with rails 4.2.0.beta2 and 4.2.0.beta4.
- It happens on both ruby 2.1.3 and 2.1.4
- So far, it only seems to happen for users on Macs, though it happens both on rubies install through homebrew and `ruby-isntall`. 

Any help or explanation you all can offer would be great. Thanks!

Backtrace:

```
1) "expired" rake tasks :cleanup:invitations should delete all expired invitations
     Failure/Error: create_list(:invitation, 3)
     NameError:
       undefined local variable or method `visit_Arel_Nodes_Quoted' for #<Arel::Visitors::DepthFirst:0x007f8292426a78>
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/visitor.rb:29:in `method_missing'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/visitor.rb:29:in `visit'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/depth_first.rb:12:in `visit'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/depth_first.rb:17:in `unary'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/visitor.rb:29:in `visit'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/depth_first.rb:12:in `visit'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/depth_first.rb:155:in `visit_Arel_Nodes_SelectStatement'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/visitor.rb:29:in `visit'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/depth_first.rb:12:in `visit'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/visitors/visitor.rb:19:in `accept'
     # /Users/Jake/.gem/ruby/2.1.3/gems/arel-6.0.0.beta2/lib/arel/nodes/node.rb:56:in `each'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/relation/query_methods.rb:886:in `grep'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/relation/query_methods.rb:886:in `build_arel'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/relation/query_methods.rb:857:in `arel'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/relation/finder_methods.rb:310:in `exists?'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/querying.rb:3:in `exists?'
     # ./app/models/callbacks/generate_unique.rb:19:in `block in before_validation'
     # ./app/models/callbacks/generate_unique.rb:15:in `loop'
     # ./app/models/callbacks/generate_unique.rb:15:in `before_validation'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/callbacks.rb:450:in `public_send'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/callbacks.rb:450:in `block in make_lambda'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/callbacks.rb:163:in `call'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/callbacks.rb:163:in `block in halting'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/callbacks.rb:92:in `call'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/callbacks.rb:92:in `_run_callbacks'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/callbacks.rb:734:in `_run_validation_callbacks'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activemodel-4.2.0.beta4/lib/active_model/validations/callbacks.rb:113:in `run_validations!'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activemodel-4.2.0.beta4/lib/active_model/validations.rb:334:in `valid?'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/validations.rb:57:in `valid?'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/validations.rb:82:in `perform_validations'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/validations.rb:42:in `save!'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/transactions.rb:289:in `block in save!'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/transactions.rb:345:in `block in with_transaction_returning_status'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/connection_adapters/abstract/transaction.rb:188:in `within_new_transaction'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/transactions.rb:218:in `transaction'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/transactions.rb:342:in `with_transaction_returning_status'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activerecord-4.2.0.beta4/lib/active_record/transactions.rb:289:in `save!'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/configuration.rb:14:in `block in initialize'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluation.rb:15:in `[]'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluation.rb:15:in `create'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:12:in `block in result'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:9:in `tap'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:9:in `result'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory.rb:42:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:23:in `block in run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/notifications.rb:166:in `instrument'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:22:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/build.rb:5:in `association'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluator.rb:31:in `association'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute/association.rb:19:in `block in to_proc'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluator.rb:71:in `instance_exec'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluator.rb:71:in `block in define_attribute'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:56:in `get'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:16:in `block (2 levels) in object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:15:in `each'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:15:in `block in object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:14:in `tap'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:14:in `object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluation.rb:12:in `object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/build.rb:9:in `result'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory.rb:42:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:23:in `block in run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/notifications.rb:166:in `instrument'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:22:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy_syntax_method_registrar.rb:20:in `block in define_singular_strategy_method'
     # ./spec/factories/projects.rb:7:in `block (3 levels) in <top (required)>'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/callback.rb:13:in `instance_exec'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/callback.rb:13:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/callbacks_observer.rb:11:in `block in update'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/callbacks_observer.rb:10:in `each'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/callbacks_observer.rb:10:in `update'
     # /opt/rubies/ruby-2.1.3/lib/ruby/2.1.0/observer.rb:196:in `block in notify_observers'
     # /opt/rubies/ruby-2.1.3/lib/ruby/2.1.0/observer.rb:195:in `each'
     # /opt/rubies/ruby-2.1.3/lib/ruby/2.1.0/observer.rb:195:in `notify_observers'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluation.rb:20:in `notify'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:11:in `block in result'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:9:in `tap'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:9:in `result'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory.rb:42:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:23:in `block in run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/notifications.rb:166:in `instrument'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:22:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:5:in `association'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluator.rb:31:in `association'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute/association.rb:19:in `block in to_proc'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluator.rb:71:in `instance_exec'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluator.rb:71:in `block in define_attribute'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:56:in `get'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:16:in `block (2 levels) in object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:15:in `each'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:15:in `block in object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:14:in `tap'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/attribute_assigner.rb:14:in `object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/evaluation.rb:12:in `object'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy/create.rb:9:in `result'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory.rb:42:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:23:in `block in run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/activesupport-4.2.0.beta4/lib/active_support/notifications.rb:166:in `instrument'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/factory_runner.rb:22:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy_syntax_method_registrar.rb:20:in `block in define_singular_strategy_method'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy_syntax_method_registrar.rb:28:in `block (2 levels) in define_list_strategy_method'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy_syntax_method_registrar.rb:28:in `times'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy_syntax_method_registrar.rb:28:in `each'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy_syntax_method_registrar.rb:28:in `map'
     # /Users/Jake/.gem/ruby/2.1.3/gems/factory_girl-4.5.0/lib/factory_girl/strategy_syntax_method_registrar.rb:28:in `block in define_list_strategy_method'
     # ./spec/lib/tasks/expired_spec.rb:19:in `block (3 levels) in <top (required)>'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:152:in `instance_exec'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:152:in `block in run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:222:in `call'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:222:in `call'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-rails-3.1.0/lib/rspec/rails/adapters.rb:72:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:322:in `instance_exec'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:322:in `instance_exec'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/hooks.rb:380:in `execute_with'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/hooks.rb:446:in `block (2 levels) in run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:222:in `call'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:222:in `call'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/hooks.rb:447:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/hooks.rb:500:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:331:in `with_around_example_hooks'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:149:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:490:in `block in run_examples'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:486:in `map'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:486:in `run_examples'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:453:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `block in run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `map'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `block (2 levels) in run_specs'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `map'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `block in run_specs'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:53:in `report'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:107:in `run_specs'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:85:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
     # /Users/Jake/.gem/ruby/2.1.3/gems/rspec-core-3.1.7/exe/rspec:4:in `<top (required)>'
     # /Users/Jake/.gem/ruby/2.1.3/bin/rspec:23:in `load'
     # /Users/Jake/.gem/ruby/2.1.3/bin/rspec:23:in `<main>'
```
