### PR TITLE
Support Oracle bind parameter value

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -132,6 +132,10 @@ module Arel
         array
       end
 
+      def visit_Arel_Nodes_BindParam o, collector
+        collector.add_bind(o) { |i| ":a#{i}" }
+      end
+
     end
   end
 end

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -4,7 +4,8 @@ module Arel
   module Visitors
     describe 'the oracle visitor' do
       before do
-        @visitor = Oracle.new Table.engine.connection_pool
+        @visitor = Oracle.new Table.engine.connection
+        @table = Table.new(:users)
       end
 
       def compile node
@@ -163,6 +164,16 @@ module Arel
         it 'defaults to FOR UPDATE when locking' do
           node = Nodes::Lock.new(Arel.sql('FOR UPDATE'))
           compile(node).must_be_like "FOR UPDATE"
+        end
+      end
+
+      describe "Nodes::BindParam" do
+        it "increments each bind param" do
+          query = @table[:name].eq(Arel::Nodes::BindParam.new)
+            .and(@table[:id].eq(Arel::Nodes::BindParam.new))
+          compile(query).must_be_like %{
+            "users"."name" = :a1 AND "users"."id" = :a2
+          }
         end
       end
     end


### PR DESCRIPTION
This pull request supports Oracle bind parameter values named `:a1` since https://github.com/rails/arel/commit/590c784a30b13153667f8db7915998d7731e24e5 adds order to BindParams, which currently supports bind values named `$1`.

Once this pull request merged, rsim/oracle-enhanced#520 can be merged.
