### PR TITLE
{Matches,DoesNotMatch} support the ESCAPE clause with PostgreSQL

### DIFF
--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -4,11 +4,23 @@ module Arel
       private
 
       def visit_Arel_Nodes_Matches o, collector
-        infix_value o, collector, ' ILIKE '
+        collector = infix_value o, collector, ' ILIKE '
+        if o.escape
+          collector << ' ESCAPE '
+          visit o.escape, collector
+        else
+          collector
+        end
       end
 
       def visit_Arel_Nodes_DoesNotMatch o, collector
-        infix_value o, collector, ' NOT ILIKE '
+        collector = infix_value o, collector, ' NOT ILIKE '
+        if o.escape
+          collector << ' ESCAPE '
+          visit o.escape, collector
+        else
+          collector
+        end
       end
 
       def visit_Arel_Nodes_Regexp o, collector

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -58,6 +58,13 @@ module Arel
           }
         end
 
+        it "can handle ESCAPE" do
+          node = @table[:name].matches('foo!%', '!')
+          compile(node).must_be_like %{
+            "users"."name" ILIKE 'foo!%' ESCAPE '!'
+          }
+        end
+
         it 'can handle subqueries' do
           subquery = @table.project(:id).where(@table[:name].matches('foo%'))
           node = @attr.in subquery
@@ -72,6 +79,13 @@ module Arel
           node = @table[:name].does_not_match('foo%')
           compile(node).must_be_like %{
             "users"."name" NOT ILIKE 'foo%'
+          }
+        end
+
+        it "can handle ESCAPE" do
+          node = @table[:name].does_not_match('foo!%', '!')
+          compile(node).must_be_like %{
+            "users"."name" NOT ILIKE 'foo!%' ESCAPE '!'
           }
         end
 


### PR DESCRIPTION
to_SQL already has supported the ESCAPE clause in #318.
PostgreSQL can use the ESCAPE clause too.
