### PR TITLE
Delegate to Connection Visitor in WhereSQL Visitor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 script: 
   - "rake test"
   - "gem build arel.gemspec"
+env: JRUBY_OPTS=--2.0
 rvm:
   - rbx
   - jruby

--- a/lib/arel/visitors/where_sql.rb
+++ b/lib/arel/visitors/where_sql.rb
@@ -5,7 +5,11 @@ module Arel
 
       def visit_Arel_Nodes_SelectCore o, collector
         collector << "WHERE "
-        inject_join o.wheres, collector, ' AND '
+        wheres = o.wheres.map do |where|
+          Nodes::SqlLiteral.new(@connection.visitor.accept(where, collector.class.new).value)
+        end
+
+        inject_join wheres, collector, ' AND '
       end
     end
   end

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -938,6 +938,27 @@ module Arel
         manager.where_sql.must_be_like %{ WHERE "users"."id" = 10 }
       end
 
+      it 'joins wheres with AND' do
+        table   = Table.new :users
+        manager = Arel::SelectManager.new
+        manager.from table
+        manager.where table[:id].eq 10
+        manager.where table[:id].eq 11
+        manager.where_sql.must_be_like %{ WHERE "users"."id" = 10 AND "users"."id" = 11}
+      end
+
+      it 'handles database specific statements' do
+        old_visitor = Table.engine.connection.visitor
+        Table.engine.connection.visitor = Visitors::PostgreSQL.new Table.engine.connection
+        table   = Table.new :users
+        manager = Arel::SelectManager.new
+        manager.from table
+        manager.where table[:id].eq 10
+        manager.where table[:name].matches 'foo%'
+        manager.where_sql.must_be_like %{ WHERE "users"."id" = 10 AND "users"."name" ILIKE 'foo%' }
+        Table.engine.connection.visitor = old_visitor
+      end
+
       it 'returns nil when there are no wheres' do
         table   = Table.new :users
         manager = Arel::SelectManager.new


### PR DESCRIPTION
The WhereSql visitor always uses the generic ToSql visitor to create
the where clause sql statement. This means that it'll miss database
specific statements, such as 'ILIKE' in PostgreSQL. Since the
`#where_sql` method is mainly used for ActiveRecord error reporting,
this discrepancy could be confusing to users.

This patch changes the WhereSql visitor to use the its connection
visitor to generate Sql for each statement in the SelectManager's wheres
array. Then lets them be joined together with ' AND '.