### PR TITLE
Remove jruby and add jruby-head on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script:
   - "gem build arel.gemspec"
 rvm:
   - rbx
-  - jruby
+  - jruby-head
   - 2.0.0
   - 2.1
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 script: 
   - "rake test"
   - "gem build arel.gemspec"
+env:
+  global:
+    - JRUBY_OPTS='--dev -J-Xmx1024M'
 rvm:
   - rbx
   - jruby-head


### PR DESCRIPTION
Arel 7.0 dropped support for 1.9 (see f1a3421ce7083181ebd463c8147c2d4b95539ca8).
We should remove jruby (1.7.18) which only supports 1.9 and test the
latest jruby head (9.0.0.0.pre1).

After jruby 9k has been released (and Travis has updated) we can safely
switch back to jruby.

Let's see if we can omit the `allow_failures` section :raised_hands: 