### PR TITLE
Test with rbx-2 on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
 rvm:
-  - rbx
+  - rbx-2
   - jruby-head
   - 2.0.0
   - 2.1
   - ruby-head
-matrix:
-  allow_failures:
-    - rvm: rbx
 notifications:
   email: false
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 script: 
-  - "rake test"
+  - "bundle exec rake test"
   - "gem build arel.gemspec"
 env:
   global:


### PR DESCRIPTION
Using `rbx-2` is the recommended way to test with the 2.0 branch of Rubinius.