### PR TITLE
Fix column_cache: use model columns_hash

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -130,12 +130,20 @@ module Arel
 
       def column_for attr
         return unless attr
-        name    = attr.name.to_s
-        table   = attr.relation.table_name
+        name     = attr.name.to_s
+        relation = attr.relation
 
-        return nil unless table_exists? table
+        if has_columns_hash? relation
+          relation.engine.columns_hash[name]
+        elsif table_exists? relation.table_name
+          column_cache(relation.table_name)[name]
+        else
+          nil
+        end
+      end
 
-        column_cache(table)[name]
+      def has_columns_hash?(relation)
+        relation.respond_to?(:engine) && relation.engine.respond_to?(:columns_hash)
       end
 
       def column_cache(table)

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -218,6 +218,23 @@ module Arel
         @visitor.accept(test).must_be_like %{ "users"."bool" = 't' }
       end
 
+      it "uses columns_hash of engine" do
+        table = Class.new(Table) {
+          def engine
+            Class.new {
+              def columns_hash
+                { 'active' => FakeRecord::Column.new('active', :integer) }
+              end
+            }.new
+          end
+        }.new(:users)
+
+        node = Nodes::NotEqual.new(table[:active], "1")
+        @visitor.accept(node).must_be_like %{
+          "users"."active" != 1
+        }
+      end
+
       describe "Nodes::Matches" do
         it "should know how to visit" do
           node = @table[:name].matches('foo%')


### PR DESCRIPTION
In Arel 5.0/6.0, Cache of column information is stored in Arel's variable.
Since ActiveRecord model also stores a cache, Acquisition of table information is duplicated.

For example, Although columns of information has already been stored in the model, `SHOW FULL FIELDS` is executed in MySQL.
It may affect the performance.

In this fix, `ToSql#column_for` has been modified to use `ActiveRecord::Base#columns_hash`.
It would be very helpful if the fix be merged.
