### PR TITLE
Make more comprehensive use of ToSql string constants

### DIFF
--- a/lib/arel/visitors/informix.rb
+++ b/lib/arel/visitors/informix.rb
@@ -20,7 +20,7 @@ module Arel
         froms = false
         if o.source && !o.source.empty?
           froms = true
-          collector << " FROM "
+          collector << FROM
           collector = visit o.source, collector
         end
 

--- a/lib/arel/visitors/informix.rb
+++ b/lib/arel/visitors/informix.rb
@@ -25,8 +25,8 @@ module Arel
         end
 
         if o.wheres.any?
-          collector << " WHERE "
-          collector = inject_join o.wheres, collector, " AND "
+          collector << WHERE
+          collector = inject_join o.wheres, collector, AND
         end
 
         if o.groups.any?
@@ -36,7 +36,7 @@ module Arel
 
         if o.havings.any?
           collector << " HAVING "
-          collector = inject_join o.havings, collector, " AND "
+          collector = inject_join o.havings, collector, AND
         end
         collector
       end

--- a/lib/arel/visitors/mssql.rb
+++ b/lib/arel/visitors/mssql.rb
@@ -76,7 +76,7 @@ module Arel
         collector << 'FROM '
         collector = visit o.relation, collector
         if o.wheres.any?
-          collector << ' WHERE '
+          collector << WHERE
           inject_join o.wheres, collector, AND
         else
           collector

--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -60,8 +60,8 @@ module Arel
         end
 
         unless o.wheres.empty?
-          collector << " WHERE "
-          collector = inject_join o.wheres, collector, ' AND '
+          collector << WHERE
+          collector = inject_join o.wheres, collector, AND
         end
 
         unless o.orders.empty?

--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -14,7 +14,7 @@ module Arel
                         visit o.left, collector
                       end
 
-        collector << " UNION "
+        collector << UNION
 
         collector =    case o.right
                        when Arel::Nodes::Union
@@ -51,11 +51,11 @@ module Arel
       end
 
       def visit_Arel_Nodes_UpdateStatement o, collector
-        collector << "UPDATE "
+        collector << UPDATE
         collector = visit o.relation, collector
 
         unless o.values.empty?
-          collector << " SET "
+          collector << SET
           collector = inject_join o.values, collector, ', '
         end
 
@@ -65,7 +65,7 @@ module Arel
         end
 
         unless o.orders.empty?
-          collector << " ORDER BY "
+          collector << ORDER_BY
           collector = inject_join o.orders, collector, ', '
         end
 

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -6,7 +6,7 @@ module Arel
       def visit_Arel_Nodes_Matches o, collector
         collector = infix_value o, collector, ' ILIKE '
         if o.escape
-          collector << ' ESCAPE '
+          collector << ESCAPE
           visit o.escape, collector
         else
           collector
@@ -16,7 +16,7 @@ module Arel
       def visit_Arel_Nodes_DoesNotMatch o, collector
         collector = infix_value o, collector, ' NOT ILIKE '
         if o.escape
-          collector << ' ESCAPE '
+          collector << ESCAPE
           visit o.escape, collector
         else
           collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -77,7 +77,7 @@ module Arel
         collector << 'DELETE FROM '
         collector = visit o.relation, collector
         if o.wheres.any?
-          collector << ' WHERE '
+          collector << WHERE
           collector = inject_join o.wheres, collector, AND
         end
 
@@ -111,8 +111,8 @@ module Arel
         end
 
         unless wheres.empty?
-          collector << " WHERE "
-          collector = inject_join wheres, collector, " AND "
+          collector << WHERE
+          collector = inject_join wheres, collector, AND
         end
 
         collector
@@ -638,7 +638,7 @@ module Arel
       end
 
       def visit_Arel_Nodes_And o, collector
-        inject_join o.children, collector, " AND "
+        inject_join o.children, collector, AND
       end
 
       def visit_Arel_Nodes_Or o, collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -55,8 +55,13 @@ module Arel
       ORDER_BY = ' ORDER BY ' # :nodoc:
       WINDOW   = ' WINDOW '   # :nodoc:
       AND      = ' AND '      # :nodoc:
+      SET      = ' SET '      # :nodoc:
+      UNION    = ' UNION '    # :nodoc:
+      FROM     = ' FROM '     # :nodoc:
+      ESCAPE   = ' ESCAPE '   # :nodoc:
 
       DISTINCT = 'DISTINCT'   # :nodoc:
+      UPDATE   = 'UPDATE '    # :nodoc:
 
       def initialize connection
         super()
@@ -103,10 +108,10 @@ module Arel
           wheres = [Nodes::In.new(o.key, [build_subselect(o.key, o)])]
         end
 
-        collector << "UPDATE "
+        collector << UPDATE
         collector = visit o.relation, collector
         unless o.values.empty?
-          collector << " SET "
+          collector << SET
           collector = inject_join o.values, collector, ", "
         end
 
@@ -243,7 +248,7 @@ module Arel
         end
 
         if o.source && !o.source.empty?
-          collector << " FROM "
+          collector << FROM
           collector = visit o.source, collector
         end
 
@@ -306,7 +311,7 @@ module Arel
 
       def visit_Arel_Nodes_Union o, collector
         collector << "( "
-        infix_value(o, collector, " UNION ") << " )"
+        infix_value(o, collector, UNION) << " )"
       end
 
       def visit_Arel_Nodes_UnionAll o, collector
@@ -530,7 +535,7 @@ module Arel
         collector << " LIKE "
         collector = visit o.right, collector
         if o.escape
-          collector << ' ESCAPE '
+          collector << ESCAPE
           visit o.escape, collector
         else
           collector
@@ -542,7 +547,7 @@ module Arel
         collector << " NOT LIKE "
         collector = visit o.right, collector
         if o.escape
-          collector << ' ESCAPE '
+          collector << ESCAPE
           visit o.escape, collector
         else
           collector

--- a/lib/arel/visitors/where_sql.rb
+++ b/lib/arel/visitors/where_sql.rb
@@ -5,7 +5,7 @@ module Arel
 
       def visit_Arel_Nodes_SelectCore o, collector
         collector << "WHERE "
-        inject_join o.wheres, collector, ' AND '
+        inject_join o.wheres, collector, AND
       end
     end
   end


### PR DESCRIPTION
 WHERE, AND, add Add SET, UNION, FROM, ESCAPE, and UPDATE to ToSQL

Was just poking around looking to expose a variable and I did this instead. Presuming it will help with memory use and the like by reducing literal instantiation.