### PR TITLE
Fix TableAliases with Symbols when using the Oracle Visitor

### DIFF
--- a/lib/arel/nodes/binary.rb
+++ b/lib/arel/nodes/binary.rb
@@ -11,8 +11,8 @@ module Arel
 
       def initialize_copy other
         super
-        @left  = @left.clone if @left
-        @right = @right.clone if @right
+        @left  = @left.clone if @left && !@left.is_a?(Symbol)
+        @right = @right.clone if @right && !@right.is_a?(Symbol)
       end
 
       def hash


### PR DESCRIPTION
Oracle visitor failed with "TypeError: can't clone Symbol" when using a Symbol in a TableAlias. Add a test and a fix.