### PR TITLE
Fix a typo in the sql literal spec for grouped "and" equality

### DIFF
--- a/test/nodes/test_sql_literal.rb
+++ b/test/nodes/test_sql_literal.rb
@@ -56,7 +56,7 @@ module Arel
       end
 
       describe 'grouped "and" equality' do
-        it 'makes a grouping node with an or node' do
+        it 'makes a grouping node with an and node' do
           node = SqlLiteral.new('foo').eq_all([1,2])
           compile(node).must_be_like %{ (foo = 1 AND foo = 2) }
         end


### PR DESCRIPTION
Resolve a typo in the spec for sql literal.

- Replace it 'makes a grouping node with an or node' with 'makes a grouping node with an and node'