### PR TITLE
Improve error message when passed unsupported type

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -4,6 +4,12 @@ require 'arel/visitors/reduce'
 
 module Arel
   module Visitors
+    class UnsupportedVisitError < StandardError
+      def initialize(object)
+        super "Unsupported argument type: #{object.class.name}. Construct an Arel node instead."
+      end
+    end
+
     class ToSql < Arel::Visitors::Reduce
       ##
       # This is some roflscale crazy stuff.  I'm roflscaling this because
@@ -737,7 +743,7 @@ module Arel
       end
 
       def unsupported o, collector
-        raise "unsupported argument type: #{o.class.name}. Construct an Arel node instead."
+        raise UnsupportedVisitError.new(o)
       end
 
       alias :visit_ActiveSupport_Multibyte_Chars :unsupported

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -737,7 +737,7 @@ module Arel
       end
 
       def unsupported o, collector
-        raise "unsupported: #{o.class.name}"
+        raise "unsupported argument type: #{o.class.name}. Construct an Arel node instead."
       end
 
       alias :visit_ActiveSupport_Multibyte_Chars :unsupported

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -273,9 +273,9 @@ module Arel
         compile(Nodes.build_quoted(nil)).must_be_like "NULL"
       end
 
-      it "unsupported input should not raise ArgumentError" do
-        error = assert_raises(RuntimeError) { compile(nil) }
-        assert_match(/\Aunsupported/, error.message)
+      it "unsupported input should raise UnsupportedVisitError" do
+        error = assert_raises(UnsupportedVisitError) { compile(nil) }
+        assert_match(/\AUnsupported/, error.message)
       end
 
       it "should visit_Arel_SelectManager, which is a subquery" do


### PR DESCRIPTION
I'm not sure that is the best message, but I think the message needs improving, so I wanted to open a discussion about this.

If the message as I changed it makes sense in the context of all the different ways in which `unsupported` might be called, then I suppose maybe it's OK as-is. But it looked like maybe there's a better way to say it.

Basically, when upgrading some code that was failing after having worked with a `String`, it took me quite a while to figure out what this "unsupported: String" message was about, and to do so, I had to read through Arel's code. So I thought it would be better to give the other programmer some direction to where they wouldn't need to do that.

It would be even better if we could point them to a specific section of the docs that addresses how to work in Arel.

What do you think?