### PR TITLE
Dont need to quote limit

### DIFF
--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -19,7 +19,7 @@ module Arel
     end
 
     def limit
-      @ast.limit && @ast.limit.expr.expr
+      @ast.limit && @ast.limit.expr
     end
     alias :taken :limit
 
@@ -216,8 +216,8 @@ module Arel
 
     def take limit
       if limit
-        @ast.limit = Nodes::Limit.new(Nodes.build_quoted(limit))
-        @ctx.top   = Nodes::Top.new(Nodes.build_quoted(limit))
+        @ast.limit = Nodes::Limit.new(limit)
+        @ctx.top   = Nodes::Top.new(limit)
       else
         @ast.limit = nil
         @ctx.top   = nil


### PR DESCRIPTION
https://github.com/rails/arel/commit/d38352ef9e63ec6e1ffee3e4fe78101df36bd6d8 added a quote method to the LIMIT stmt, Not sure why.

FWIW, AR, is already sanitizing the limit: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L320-L328

review @sgrif @rafaelfranca @tenderlove 