### PR TITLE
After 6.0.2, undefined method `expr' for 10:Fixnum here happen in Oracle visitor

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -17,7 +17,7 @@ module Arel
 
         if o.limit && o.offset
           o        = o.dup
-          limit    = o.limit.expr.expr
+          limit    = o.limit.expr
           offset   = o.offset
           o.offset = nil
           collector << "

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -111,7 +111,7 @@ module Arel
 
           it 'creates a different subquery when there is an offset' do
             stmt = Nodes::SelectStatement.new
-            stmt.limit = Nodes::Limit.new(Nodes.build_quoted(10))
+            stmt.limit = Nodes::Limit.new(10)
             stmt.offset = Nodes::Offset.new(10)
             sql = compile stmt
             sql.must_be_like %{
@@ -126,7 +126,7 @@ module Arel
 
           it 'is idempotent with different subquery' do
             stmt = Nodes::SelectStatement.new
-            stmt.limit = Nodes::Limit.new(Nodes.build_quoted(10))
+            stmt.limit = Nodes::Limit.new(10)
             stmt.offset = Nodes::Offset.new(10)
             sql = compile stmt
             sql2 = compile stmt


### PR DESCRIPTION
6.0.0 have no issue, but 6.0.2 will having below error, No sure why, but seems will fix by change that...

```
http://localhost:3000/da_ai_buyoffs

NoMethodError in DaAiBuyoffs#index
Showing c:/git/apc/app/views/da_ai_buyoffs/index.html.erb where line #63 raised:

undefined method `expr' for 10:Fixnum
Rails.root: c:/git/apc

Application Trace | Framework Trace | Full Trace
arel (6.0.2) lib/arel/visitors/oracle.rb:20:in `visit_Arel_Nodes_SelectStatement'
arel (6.0.2) lib/arel/visitors/reduce.rb:13:in `visit'
arel (6.0.2) lib/arel/visitors/reduce.rb:7:in `accept'
activerecord (4.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:12:in `to_sql'
activerecord (4.2.3) lib/active_record/connection_adapters/abstract/query_cache.rb:67:in `select_all'
activerecord (4.2.3) lib/active_record/querying.rb:39:in `find_by_sql'
activerecord (4.2.3) lib/active_record/relation.rb:638:in `exec_queries'
activerecord (4.2.3) lib/active_record/relation.rb:514:in `load'
activerecord (4.2.3) lib/active_record/relation.rb:243:in `to_a'
will_paginate (3.0.7) lib/will_paginate/active_record.rb:134:in `block in to_a'
will_paginate (3.0.7) lib/will_paginate/collection.rb:96:in `create'
will_paginate (3.0.7) lib/will_paginate/active_record.rb:133:in `to_a'
C:in `each'
app/views/da_ai_buyoffs/index.html.erb:63:in `_app_views_da_ai_buyoffs_index_html_erb___102643328_132164256'
```