### PR TITLE
Follow up #370 for Oracle, to fix undefined method `expr' for 10:Fixnum bug.

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -17,7 +17,7 @@ module Arel
 
         if o.limit && o.offset
           o        = o.dup
-          limit    = o.limit.expr.expr
+          limit    = o.limit.expr
           offset   = o.offset
           o.offset = nil
           collector << "

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -111,7 +111,7 @@ module Arel
 
           it 'creates a different subquery when there is an offset' do
             stmt = Nodes::SelectStatement.new
-            stmt.limit = Nodes::Limit.new(Nodes.build_quoted(10))
+            stmt.limit = Nodes::Limit.new(10)
             stmt.offset = Nodes::Offset.new(10)
             sql = compile stmt
             sql.must_be_like %{
@@ -126,7 +126,7 @@ module Arel
 
           it 'is idempotent with different subquery' do
             stmt = Nodes::SelectStatement.new
-            stmt.limit = Nodes::Limit.new(Nodes.build_quoted(10))
+            stmt.limit = Nodes::Limit.new(10)
             stmt.offset = Nodes::Offset.new(10)
             sql = compile stmt
             sql2 = compile stmt


### PR DESCRIPTION
@rafaelfranca 
per @yahonda suggestion at #376, try to fix at master branch first and backport into `6-0-stable` branch.