### PR TITLE
Add OrderPredications back into Nodes::Function

### DIFF
--- a/lib/arel/nodes/function.rb
+++ b/lib/arel/nodes/function.rb
@@ -3,6 +3,7 @@ module Arel
     class Function < Arel::Nodes::Node
       include Arel::Predications
       include Arel::WindowPredications
+      include Arel::OrderPredications
       attr_accessor :expressions, :alias, :distinct
 
       def initialize expr, aliaz = nil

--- a/test/nodes/test_sum.rb
+++ b/test/nodes/test_sum.rb
@@ -21,4 +21,13 @@ describe Arel::Nodes::Sum do
       assert_equal 2, array.uniq.size
     end
   end
+  
+  describe 'order' do
+    it 'should order the sum' do
+      table = Arel::Table.new :users
+      table[:id].sum.desc.to_sql.must_be_like %{
+        SUM("users"."id") DESC
+      }
+    end
+  end
 end


### PR DESCRIPTION
Removed (accidentally?) here https://github.com/rails/arel/commit/7bf868e320efb0b53b0ce51afb925174e5db2377.  Allows to order by function (sum, avg, etc).