### PR TITLE
Don't clone TableAlias descendants.

### DIFF
--- a/lib/arel/nodes/table_alias.rb
+++ b/lib/arel/nodes/table_alias.rb
@@ -20,6 +20,10 @@ module Arel
       def able_to_type_cast?
         relation.respond_to?(:able_to_type_cast?) && relation.able_to_type_cast?
       end
+
+      def clone
+        TableAlias.new(left, right)
+      end
     end
   end
 end

--- a/test/nodes/test_table_alias.rb
+++ b/test/nodes/test_table_alias.rb
@@ -23,6 +23,14 @@ module Arel
           assert_equal 2, array.uniq.size
         end
       end
+
+      describe '#clone' do
+        it 'works when using a symbol for the alias' do
+          relation = Table.new(:users)
+          node     = TableAlias.new relation, :foo
+          assert node.clone
+        end
+      end
     end
   end
 end

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -124,6 +124,24 @@ module Arel
             }
           end
 
+          it 'accounts for TableAliases with Symbols' do
+            table = Table.new(:some_table)
+            table_alias = Nodes::TableAlias.new(table, :some_alias)
+            core = Nodes::SelectCore.new
+            core.source = Arel::Nodes::JoinSource.new(table_alias, [])
+            stmt = Nodes::SelectStatement.new([core])
+            stmt.limit = Nodes::Limit.new(10)
+            stmt.offset = Nodes::Offset.new(10)
+            compile(stmt).must_be_like %{
+              SELECT * FROM (
+                SELECT raw_sql_.*, rownum raw_rnum_
+                FROM (SELECT FROM "some_table" "some_alias" ) raw_sql_
+                WHERE rownum <= 20
+              )
+              WHERE raw_rnum_ > 10
+            }
+          end
+
           it 'is idempotent with different subquery' do
             stmt = Nodes::SelectStatement.new
             stmt.limit = Nodes::Limit.new(10)


### PR DESCRIPTION
Fixes Oracle visitor can't clone Symbol error when using table aliases. Replaces #360.
