### PR TITLE
Use constants in to sql

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -112,7 +112,7 @@ module Arel
 
         unless wheres.empty?
           collector << " WHERE "
-          collector = inject_join wheres, collector, " AND "
+          collector = inject_join wheres, collector, AND
         end
 
         collector
@@ -648,7 +648,7 @@ module Arel
       end
 
       def visit_Arel_Nodes_And o, collector
-        inject_join o.children, collector, " AND "
+        inject_join o.children, collector, AND
       end
 
       def visit_Arel_Nodes_Or o, collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -343,13 +343,13 @@ module Arel
         end
 
         if o.orders.any?
-          collector << ' ' if o.partitions.any?
+          collector << SPACE if o.partitions.any?
           collector << ORDER_BY
           collector = inject_join o.orders, collector, COMMA
         end
 
         if o.framing
-          collector << ' ' if o.partitions.any? or o.orders.any?
+          collector << SPACE if o.partitions.any? or o.orders.any?
           collector = visit o.framing, collector
         end
 
@@ -495,7 +495,7 @@ module Arel
 
       def visit_Arel_Nodes_TableAlias o, collector
         collector = visit o.relation, collector
-        collector << " "
+        collector << SPACE
         collector << quote_table_name(o.name)
       end
 
@@ -558,8 +558,8 @@ module Arel
           collector = visit o.left, collector
         end
         if o.right.any?
-          collector << " " if o.left
-          collector = inject_join o.right, collector, ' '
+          collector << SPACE if o.left
+          collector = inject_join o.right, collector, SPACE
         end
         collector
       end
@@ -586,7 +586,7 @@ module Arel
       def visit_Arel_Nodes_OuterJoin o, collector
         collector << "LEFT OUTER JOIN "
         collector = visit o.left, collector
-        collector << " "
+        collector << SPACE
         visit o.right, collector
       end
 
@@ -791,7 +791,7 @@ module Arel
 
       def maybe_visit thing, collector
         return collector unless thing
-        collector << " "
+        collector << SPACE
         visit thing, collector
       end
 

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -57,6 +57,7 @@ module Arel
       AND       = ' AND '.freeze      # :nodoc:
       AS        = ' AS '.freeze       # :nodoc:
       UNBOUNDED = 'UNBOUNDED'.freeze  # :nodoc:
+      ESCAPE    = ' ESCAPE '.freeze   # :nodoc:
 
       DISTINCT  = 'DISTINCT '.freeze  # :nodoc:
 
@@ -536,7 +537,7 @@ module Arel
         collector << " LIKE "
         collector = visit o.right, collector
         if o.escape
-          collector << ' ESCAPE '
+          collector << ESCAPE
           visit o.escape, collector
         else
           collector
@@ -548,7 +549,7 @@ module Arel
         collector << " NOT LIKE "
         collector = visit o.right, collector
         if o.escape
-          collector << ' ESCAPE '
+          collector << ESCAPE
           visit o.escape, collector
         else
           collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -48,15 +48,15 @@ module Arel
       # specialized for specific databases when necessary.
       #
 
-      WHERE    = ' WHERE '    # :nodoc:
-      SPACE    = ' '          # :nodoc:
-      COMMA    = ', '         # :nodoc:
-      GROUP_BY = ' GROUP BY ' # :nodoc:
-      ORDER_BY = ' ORDER BY ' # :nodoc:
-      WINDOW   = ' WINDOW '   # :nodoc:
-      AND      = ' AND '      # :nodoc:
+      WHERE    = ' WHERE '.freeze    # :nodoc:
+      SPACE    = ' '.freeze          # :nodoc:
+      COMMA    = ', '.freeze         # :nodoc:
+      GROUP_BY = ' GROUP BY '.freeze # :nodoc:
+      ORDER_BY = ' ORDER BY '.freeze # :nodoc:
+      WINDOW   = ' WINDOW '.freeze   # :nodoc:
+      AND      = ' AND '.freeze      # :nodoc:
 
-      DISTINCT = 'DISTINCT'   # :nodoc:
+      DISTINCT = 'DISTINCT'.freeze   # :nodoc:
 
       def initialize connection
         super()

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -77,7 +77,7 @@ module Arel
         collector << 'DELETE FROM '
         collector = visit o.relation, collector
         if o.wheres.any?
-          collector << ' WHERE '
+          collector << WHERE
           collector = inject_join o.wheres, collector, AND
         end
 
@@ -111,7 +111,7 @@ module Arel
         end
 
         unless wheres.empty?
-          collector << " WHERE "
+          collector << WHERE
           collector = inject_join wheres, collector, AND
         end
 

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -59,8 +59,8 @@ module Arel
       DISTINCT = 'DISTINCT'.freeze   # :nodoc:
 
       def initialize connection
-        super()
-        @connection     = connection
+        super
+        @connection = connection
       end
 
       def compile node, &block

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -56,7 +56,7 @@ module Arel
       WINDOW   = ' WINDOW '.freeze   # :nodoc:
       AND      = ' AND '.freeze      # :nodoc:
 
-      DISTINCT = 'DISTINCT'.freeze   # :nodoc:
+      DISTINCT = 'DISTINCT '.freeze   # :nodoc:
 
       def initialize connection
         super
@@ -458,7 +458,7 @@ module Arel
       def visit_Arel_Nodes_NamedFunction o, collector
         collector << o.name
         collector << "("
-        collector << "DISTINCT " if o.distinct
+        collector << DISTINCT if o.distinct
         collector = inject_join(o.expressions, collector, COMMA) << ")"
         if o.alias
           collector << " AS "
@@ -815,7 +815,7 @@ module Arel
       def aggregate name, o, collector
         collector << "#{name}("
         if o.distinct
-          collector << "DISTINCT "
+          collector << DISTINCT
         end
         collector = inject_join(o.expressions, collector, COMMA) << ")"
         if o.alias

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -48,16 +48,17 @@ module Arel
       # specialized for specific databases when necessary.
       #
 
-      WHERE    = ' WHERE '.freeze    # :nodoc:
-      SPACE    = ' '.freeze          # :nodoc:
-      COMMA    = ', '.freeze         # :nodoc:
-      GROUP_BY = ' GROUP BY '.freeze # :nodoc:
-      ORDER_BY = ' ORDER BY '.freeze # :nodoc:
-      WINDOW   = ' WINDOW '.freeze   # :nodoc:
-      AND      = ' AND '.freeze      # :nodoc:
-      AS       = ' AS '.freeze       # :nodoc:
+      WHERE     = ' WHERE '.freeze    # :nodoc:
+      SPACE     = ' '.freeze          # :nodoc:
+      COMMA     = ', '.freeze         # :nodoc:
+      GROUP_BY  = ' GROUP BY '.freeze # :nodoc:
+      ORDER_BY  = ' ORDER BY '.freeze # :nodoc:
+      WINDOW    = ' WINDOW '.freeze   # :nodoc:
+      AND       = ' AND '.freeze      # :nodoc:
+      AS        = ' AS '.freeze       # :nodoc:
+      UNBOUNDED = 'UNBOUNDED'.freeze  # :nodoc:
 
-      DISTINCT = 'DISTINCT '.freeze  # :nodoc:
+      DISTINCT  = 'DISTINCT '.freeze  # :nodoc:
 
       def initialize connection
         super
@@ -379,7 +380,7 @@ module Arel
         collector = if o.expr
                       visit o.expr, collector
                     else
-                      collector << "UNBOUNDED"
+                      collector << UNBOUNDED
                     end
 
         collector << " PRECEDING"
@@ -389,7 +390,7 @@ module Arel
         collector = if o.expr
                       visit o.expr, collector
                     else
-                      collector << "UNBOUNDED"
+                      collector << UNBOUNDED
                     end
 
         collector << " FOLLOWING"

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -107,7 +107,7 @@ module Arel
         collector = visit o.relation, collector
         unless o.values.empty?
           collector << " SET "
-          collector = inject_join o.values, collector, ", "
+          collector = inject_join o.values, collector, COMMA
         end
 
         unless wheres.empty?
@@ -124,7 +124,7 @@ module Arel
         if o.columns.any?
           collector << " (#{o.columns.map { |x|
             quote_column_name x.name
-          }.join ', '})"
+          }.join COMMA})"
         end
 
         if o.values
@@ -193,7 +193,7 @@ module Arel
             collector << quote(value, attr && column_for(attr)).to_s
           end
           unless i == len
-            collector << ', '
+            collector << COMMA
           end
         }
 
@@ -300,12 +300,12 @@ module Arel
 
       def visit_Arel_Nodes_With o, collector
         collector << "WITH "
-        inject_join o.children, collector, ', '
+        inject_join o.children, collector, COMMA
       end
 
       def visit_Arel_Nodes_WithRecursive o, collector
         collector << "WITH RECURSIVE "
-        inject_join o.children, collector, ', '
+        inject_join o.children, collector, COMMA
       end
 
       def visit_Arel_Nodes_Union o, collector
@@ -339,13 +339,13 @@ module Arel
 
         if o.partitions.any?
           collector << "PARTITION BY "
-          collector = inject_join o.partitions, collector, ", "
+          collector = inject_join o.partitions, collector, COMMA
         end
 
         if o.orders.any?
           collector << ' ' if o.partitions.any?
           collector << "ORDER BY "
-          collector = inject_join o.orders, collector, ", "
+          collector = inject_join o.orders, collector, COMMA
         end
 
         if o.framing
@@ -459,7 +459,7 @@ module Arel
         collector << o.name
         collector << "("
         collector << "DISTINCT " if o.distinct
-        collector = inject_join(o.expressions, collector, ", ") << ")"
+        collector = inject_join(o.expressions, collector, COMMA) << ")"
         if o.alias
           collector << " AS "
           visit o.alias, collector
@@ -767,7 +767,7 @@ module Arel
       alias :visit_Arel_Nodes_Division       :visit_Arel_Nodes_InfixOperation
 
       def visit_Array o, collector
-        inject_join o, collector, ", "
+        inject_join o, collector, COMMA
       end
       alias :visit_Set :visit_Array
 
@@ -817,7 +817,7 @@ module Arel
         if o.distinct
           collector << "DISTINCT "
         end
-        collector = inject_join(o.expressions, collector, ", ") << ")"
+        collector = inject_join(o.expressions, collector, COMMA) << ")"
         if o.alias
           collector << " AS "
           visit o.alias, collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -344,7 +344,7 @@ module Arel
 
         if o.orders.any?
           collector << ' ' if o.partitions.any?
-          collector << "ORDER BY "
+          collector << ORDER_BY
           collector = inject_join o.orders, collector, COMMA
         end
 

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -55,6 +55,7 @@ module Arel
       ORDER_BY = ' ORDER BY '.freeze # :nodoc:
       WINDOW   = ' WINDOW '.freeze   # :nodoc:
       AND      = ' AND '.freeze      # :nodoc:
+      AS       = ' AS '.freeze       # :nodoc:
 
       DISTINCT = 'DISTINCT '.freeze   # :nodoc:
 
@@ -140,7 +141,7 @@ module Arel
         collector << "EXISTS ("
         collector = visit(o.expressions, collector) << ")"
         if o.alias
-          collector << " AS "
+          collector << AS
           visit o.alias, collector
         else
           collector
@@ -330,7 +331,7 @@ module Arel
 
       def visit_Arel_Nodes_NamedWindow o, collector
         collector << quote_column_name(o.name)
-        collector << " AS "
+        collector << AS
         visit_Arel_Nodes_Window o, collector
       end
 
@@ -461,7 +462,7 @@ module Arel
         collector << DISTINCT if o.distinct
         collector = inject_join(o.expressions, collector, COMMA) << ")"
         if o.alias
-          collector << " AS "
+          collector << AS
           visit o.alias, collector
         else
           collector
@@ -698,7 +699,7 @@ module Arel
 
       def visit_Arel_Nodes_As o, collector
         collector = visit o.left, collector
-        collector << " AS "
+        collector << AS
         visit o.right, collector
       end
 
@@ -819,7 +820,7 @@ module Arel
         end
         collector = inject_join(o.expressions, collector, COMMA) << ")"
         if o.alias
-          collector << " AS "
+          collector << AS
           visit o.alias, collector
         else
           collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -57,7 +57,7 @@ module Arel
       AND      = ' AND '.freeze      # :nodoc:
       AS       = ' AS '.freeze       # :nodoc:
 
-      DISTINCT = 'DISTINCT '.freeze   # :nodoc:
+      DISTINCT = 'DISTINCT '.freeze  # :nodoc:
 
       def initialize connection
         super


### PR DESCRIPTION
I was going through the comments at the top and discovered that strings were a major hotsport for creating SQL. Therefore, I decided to continue looking through the source and realized... wait... there's still spots to optimize. I froze the constants to give it an ever so minor perf boost (fingers crossed) and made sure that some of the existing constants were used.

Also added a new one for `' AS '`, `'UNBOUNDED'`, and `' ESCAPED '` and would love to add more; this way we could also have a laundry list of text that we use :D

Parenthesis are also widely used and they can also be moved to the constants. The only problem is that some of the require a space before/after and some of the shouldn't. I'm think this should also get tacked on to this PR:

```ruby
OPEN_PAREN    = '('.freeze
OPEN_PAREN_S  = '( '.freeze
CLOSE_PAREN   = ')'.freeze
CLOSE_PAREN_S = ') '.freeze
```