### PR TITLE
Preserve eq_any with empty collection behavior.

### DIFF
--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -366,7 +366,16 @@ module Arel
             SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 OR "users"."id" = 2)
           }
         end
-
+        
+        it "should handle empty collection" do
+          relation = Table.new(:users)
+          mgr = relation.project relation[:id]
+          mgr.where relation[:id].eq_any([])
+          mgr.to_sql.must_be_like %{
+            SELECT "users"."id" FROM "users" WHERE (NULL)
+          }
+        end
+        
         it 'should not eat input' do
           relation = Table.new(:users)
           mgr = relation.project relation[:id]


### PR DESCRIPTION
Preserve and ensure the behavior does not change in Future 5-0-stable branch for eq_any with an empty collection as input.  This has already changed in the 6-0-stable (breaking change).  See issue #368