### PR TITLE
Case insensitivite match/regular expressions

### DIFF
--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -30,6 +30,7 @@ require 'arel/nodes/table_alias'
 require 'arel/nodes/infix_operation'
 require 'arel/nodes/over'
 require 'arel/nodes/matches'
+require 'arel/nodes/regexp'
 
 # nary
 require 'arel/nodes/and'

--- a/lib/arel/nodes/binary.rb
+++ b/lib/arel/nodes/binary.rb
@@ -38,9 +38,7 @@ module Arel
       LessThanOrEqual
       NotEqual
       NotIn
-      NotRegexp
       Or
-      Regexp
       Union
       UnionAll
       Intersect

--- a/lib/arel/nodes/matches.rb
+++ b/lib/arel/nodes/matches.rb
@@ -2,10 +2,12 @@ module Arel
   module Nodes
     class Matches < Binary
       attr_reader :escape
+      attr_accessor :case_sensitive
 
-      def initialize(left, right, escape = nil)
+      def initialize(left, right, escape = nil, case_sensitive = false)
         super(left, right)
         @escape = escape && Nodes.build_quoted(escape)
+        @case_sensitive = case_sensitive
       end
     end
 

--- a/lib/arel/nodes/regexp.rb
+++ b/lib/arel/nodes/regexp.rb
@@ -1,0 +1,14 @@
+module Arel
+  module Nodes
+    class Regexp < Binary
+      attr_accessor :case_sensitive
+
+      def initialize(left, right, case_sensitive = true)
+        super(left, right)
+        @case_sensitive = case_sensitive
+      end
+    end
+
+    class NotRegexp < Regexp; end
+  end
+end

--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -118,20 +118,20 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
       grouping_all :not_in, others
     end
 
-    def matches other, escape = nil
-      Nodes::Matches.new self, quoted_node(other), escape
+    def matches other, escape = nil, case_sensitive = false
+      Nodes::Matches.new self, quoted_node(other), escape, case_sensitive
     end
 
-    def matches_any others, escape = nil
-      grouping_any :matches, others, escape
+    def matches_any others, escape = nil, case_sensitive = false
+      grouping_any :matches, others, escape, case_sensitive
     end
 
-    def matches_all others, escape = nil
-      grouping_all :matches, others, escape
+    def matches_all others, escape = nil, case_sensitive = false
+      grouping_all :matches, others, escape, case_sensitive
     end
 
-    def does_not_match other, escape = nil
-      Nodes::DoesNotMatch.new self, quoted_node(other), escape
+    def does_not_match other, escape = nil, case_sensitive = false
+      Nodes::DoesNotMatch.new self, quoted_node(other), escape, case_sensitive
     end
 
     def does_not_match_any others, escape = nil

--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -122,6 +122,10 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
       Nodes::Matches.new self, quoted_node(other), escape, case_sensitive
     end
 
+    def matches_regexp other, case_sensitive = true
+      Nodes::Regexp.new self, quoted_node(other), case_sensitive
+    end
+
     def matches_any others, escape = nil, case_sensitive = false
       grouping_any :matches, others, escape, case_sensitive
     end
@@ -132,6 +136,10 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
 
     def does_not_match other, escape = nil, case_sensitive = false
       Nodes::DoesNotMatch.new self, quoted_node(other), escape, case_sensitive
+    end
+
+    def does_not_match_regexp other, case_sensitive = true
+      Nodes::NotRegexp.new self, quoted_node(other), case_sensitive
     end
 
     def does_not_match_any others, escape = nil

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -26,11 +26,13 @@ module Arel
       end
 
       def visit_Arel_Nodes_Regexp o, collector
-        infix_value o, collector, ' ~ '
+        op = o.case_sensitive ? ' ~ ' : ' ~* '
+        infix_value o, collector, op
       end
 
       def visit_Arel_Nodes_NotRegexp o, collector
-        infix_value o, collector, ' !~ '
+        op = o.case_sensitive ? ' !~ ' : ' !~* '
+        infix_value o, collector, op
       end
 
       def visit_Arel_Nodes_DistinctOn o, collector

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -4,7 +4,8 @@ module Arel
       private
 
       def visit_Arel_Nodes_Matches o, collector
-        collector = infix_value o, collector, ' ILIKE '
+        op = o.case_sensitive ? ' LIKE ' : ' ILIKE '
+        collector = infix_value o, collector, op
         if o.escape
           collector << ' ESCAPE '
           visit o.escape, collector
@@ -14,7 +15,8 @@ module Arel
       end
 
       def visit_Arel_Nodes_DoesNotMatch o, collector
-        collector = infix_value o, collector, ' NOT ILIKE '
+        op = o.case_sensitive ? ' NOT LIKE ' : ' NOT ILIKE '
+        collector = infix_value o, collector, op
         if o.escape
           collector << ' ESCAPE '
           visit o.escape, collector

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -58,6 +58,13 @@ module Arel
           }
         end
 
+        it "should know how to visit case sensitive" do
+          node = @table[:name].matches('foo%', nil, true)
+          compile(node).must_be_like %{
+            "users"."name" LIKE 'foo%'
+          }
+        end
+
         it "can handle ESCAPE" do
           node = @table[:name].matches('foo!%', '!')
           compile(node).must_be_like %{
@@ -79,6 +86,13 @@ module Arel
           node = @table[:name].does_not_match('foo%')
           compile(node).must_be_like %{
             "users"."name" NOT ILIKE 'foo%'
+          }
+        end
+
+        it "should know how to visit case sensitive" do
+          node = @table[:name].does_not_match('foo%', nil, true)
+          compile(node).must_be_like %{
+            "users"."name" NOT LIKE 'foo%'
           }
         end
 

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -114,48 +114,48 @@ module Arel
 
       describe "Nodes::Regexp" do
         it "should know how to visit" do
-          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo%'))
+          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo.*'))
           compile(node).must_be_like %{
-            "users"."name" ~ 'foo%'
+            "users"."name" ~ 'foo.*'
           }
         end
 
         it "can handle case insensitive" do
-          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo%'), false)
+          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo.*'), false)
           compile(node).must_be_like %{
-            "users"."name" ~* 'foo%'
+            "users"."name" ~* 'foo.*'
           }
         end
 
         it 'can handle subqueries' do
-          subquery = @table.project(:id).where(Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo%')))
+          subquery = @table.project(:id).where(Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo.*')))
           node = @attr.in subquery
           compile(node).must_be_like %{
-            "users"."id" IN (SELECT id FROM "users" WHERE "users"."name" ~ 'foo%')
+            "users"."id" IN (SELECT id FROM "users" WHERE "users"."name" ~ 'foo.*')
           }
         end
       end
 
       describe "Nodes::NotRegexp" do
         it "should know how to visit" do
-          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo%'))
+          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo.*'))
           compile(node).must_be_like %{
-            "users"."name" !~ 'foo%'
+            "users"."name" !~ 'foo.*'
           }
         end
 
         it "can handle case insensitive" do
-          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo%'), false)
+          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo.*'), false)
           compile(node).must_be_like %{
-            "users"."name" !~* 'foo%'
+            "users"."name" !~* 'foo.*'
           }
         end
 
         it 'can handle subqueries' do
-          subquery = @table.project(:id).where(Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo%')))
+          subquery = @table.project(:id).where(Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo.*')))
           node = @attr.in subquery
           compile(node).must_be_like %{
-            "users"."id" IN (SELECT id FROM "users" WHERE "users"."name" !~ 'foo%')
+            "users"."id" IN (SELECT id FROM "users" WHERE "users"."name" !~ 'foo.*')
           }
         end
       end

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -120,6 +120,13 @@ module Arel
           }
         end
 
+        it "can handle case insensitive" do
+          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo%'), false)
+          compile(node).must_be_like %{
+            "users"."name" ~* 'foo%'
+          }
+        end
+
         it 'can handle subqueries' do
           subquery = @table.project(:id).where(Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo%')))
           node = @attr.in subquery
@@ -134,6 +141,13 @@ module Arel
           node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo%'))
           compile(node).must_be_like %{
             "users"."name" !~ 'foo%'
+          }
+        end
+
+        it "can handle case insensitive" do
+          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo%'), false)
+          compile(node).must_be_like %{
+            "users"."name" !~* 'foo%'
           }
         end
 

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -53,6 +53,8 @@ module Arel
       describe "Nodes::Matches" do
         it "should know how to visit" do
           node = @table[:name].matches('foo%')
+          node.must_be_kind_of Nodes::Matches
+          node.case_sensitive.must_equal(false)
           compile(node).must_be_like %{
             "users"."name" ILIKE 'foo%'
           }
@@ -60,6 +62,7 @@ module Arel
 
         it "should know how to visit case sensitive" do
           node = @table[:name].matches('foo%', nil, true)
+          node.case_sensitive.must_equal(true)
           compile(node).must_be_like %{
             "users"."name" LIKE 'foo%'
           }
@@ -84,6 +87,8 @@ module Arel
       describe "Nodes::DoesNotMatch" do
         it "should know how to visit" do
           node = @table[:name].does_not_match('foo%')
+          node.must_be_kind_of Nodes::DoesNotMatch
+          node.case_sensitive.must_equal(false)
           compile(node).must_be_like %{
             "users"."name" NOT ILIKE 'foo%'
           }
@@ -91,6 +96,7 @@ module Arel
 
         it "should know how to visit case sensitive" do
           node = @table[:name].does_not_match('foo%', nil, true)
+          node.case_sensitive.must_equal(true)
           compile(node).must_be_like %{
             "users"."name" NOT LIKE 'foo%'
           }

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -114,21 +114,25 @@ module Arel
 
       describe "Nodes::Regexp" do
         it "should know how to visit" do
-          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo.*'))
+          node = @table[:name].matches_regexp('foo.*')
+          node.must_be_kind_of Nodes::Regexp
+          node.case_sensitive.must_equal(true)
           compile(node).must_be_like %{
             "users"."name" ~ 'foo.*'
           }
         end
 
         it "can handle case insensitive" do
-          node = Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo.*'), false)
+          node = @table[:name].matches_regexp('foo.*', false)
+          node.must_be_kind_of Nodes::Regexp
+          node.case_sensitive.must_equal(false)
           compile(node).must_be_like %{
             "users"."name" ~* 'foo.*'
           }
         end
 
         it 'can handle subqueries' do
-          subquery = @table.project(:id).where(Arel::Nodes::Regexp.new(@table[:name], Nodes.build_quoted('foo.*')))
+          subquery = @table.project(:id).where(@table[:name].matches_regexp('foo.*'))
           node = @attr.in subquery
           compile(node).must_be_like %{
             "users"."id" IN (SELECT id FROM "users" WHERE "users"."name" ~ 'foo.*')
@@ -138,21 +142,24 @@ module Arel
 
       describe "Nodes::NotRegexp" do
         it "should know how to visit" do
-          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo.*'))
+          node = @table[:name].does_not_match_regexp('foo.*')
+          node.must_be_kind_of Nodes::NotRegexp
+          node.case_sensitive.must_equal(true)
           compile(node).must_be_like %{
             "users"."name" !~ 'foo.*'
           }
         end
 
         it "can handle case insensitive" do
-          node = Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo.*'), false)
+          node = @table[:name].does_not_match_regexp('foo.*', false)
+          node.case_sensitive.must_equal(false)
           compile(node).must_be_like %{
             "users"."name" !~* 'foo.*'
           }
         end
 
         it 'can handle subqueries' do
-          subquery = @table.project(:id).where(Arel::Nodes::NotRegexp.new(@table[:name], Nodes.build_quoted('foo.*')))
+          subquery = @table.project(:id).where(@table[:name].does_not_match_regexp('foo.*'))
           node = @attr.in subquery
           compile(node).must_be_like %{
             "users"."id" IN (SELECT id FROM "users" WHERE "users"."name" !~ 'foo.*')


### PR DESCRIPTION
Hello all,

Postgres supports case sensitive and insensitive operations.
Regular expressions match (`~`) currently defaults to case sensitive but match (`LIKE`) defaults to case insensitive.

The goal of this PR is to

1. Make case sensitivity explicit for match and regular expression match.
2. Introduce predicates `matches_regexp` and `does_not_match_regexp`.

I'd like it if both regular expressions and like match defaulted to case sensitivity, but that would change the def sql generated by postgres and I assume that is discouraged.

If you would like me to make both operators default to case sensitive (or case insensitive), let me know.

/cc @matthewd @tenderlove thoughts?