### PR TITLE
Add database specific string concatenation

### DIFF
--- a/lib/arel/nodes/infix_operation.rb
+++ b/lib/arel/nodes/infix_operation.rb
@@ -40,5 +40,10 @@ module Arel
       end
     end
 
+    class Concat < InfixOperation
+      def initialize left, right
+        super('||', left, right)
+      end
+    end
   end
 end

--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -202,6 +202,10 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
       Nodes::Case.new(self).when quoted_node(right)
     end
 
+    def concat other
+      Nodes::Concat.new self, other
+    end
+
     private
 
     def grouping_any method_id, others, *extras

--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -72,6 +72,7 @@ module Arel
       alias :visit_Arel_Nodes_As                 :binary
       alias :visit_Arel_Nodes_Assignment         :binary
       alias :visit_Arel_Nodes_Between            :binary
+      alias :visit_Arel_Nodes_Concat             :binary
       alias :visit_Arel_Nodes_DeleteStatement    :binary
       alias :visit_Arel_Nodes_DoesNotMatch       :binary
       alias :visit_Arel_Nodes_Equality           :binary

--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -176,6 +176,7 @@ module Arel
       alias :visit_Arel_Nodes_As                 :binary
       alias :visit_Arel_Nodes_Assignment         :binary
       alias :visit_Arel_Nodes_Between            :binary
+      alias :visit_Arel_Nodes_Concat             :binary
       alias :visit_Arel_Nodes_DoesNotMatch       :binary
       alias :visit_Arel_Nodes_Equality           :binary
       alias :visit_Arel_Nodes_GreaterThan        :binary

--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -72,6 +72,14 @@ module Arel
         maybe_visit o.limit, collector
       end
 
+      def visit_Arel_Nodes_Concat o, collector
+        collector << " CONCAT("
+        visit o.left, collector
+        collector << ", "
+        visit o.right, collector
+        collector << ") "
+        collector
+      end
     end
   end
 end

--- a/test/visitors/test_depth_first.rb
+++ b/test/visitors/test_depth_first.rb
@@ -103,6 +103,7 @@ module Arel
       [
         Arel::Nodes::Assignment,
         Arel::Nodes::Between,
+        Arel::Nodes::Concat,
         Arel::Nodes::DoesNotMatch,
         Arel::Nodes::Equality,
         Arel::Nodes::GreaterThan,

--- a/test/visitors/test_mysql.rb
+++ b/test/visitors/test_mysql.rb
@@ -55,6 +55,24 @@ module Arel
           compile(node).must_be_like "LOCK IN SHARE MODE"
         end
       end
+
+      describe "concat" do
+        it "concats columns" do
+          @table = Table.new(:users)
+          query = @table[:name].concat(@table[:name])
+          compile(query).must_be_like %{
+            CONCAT("users"."name", "users"."name")
+          }
+        end
+
+        it "concats a string" do
+          @table = Table.new(:users)
+          query = @table[:name].concat(Nodes.build_quoted('abc'))
+          compile(query).must_be_like %{
+            CONCAT("users"."name", 'abc')
+          }
+        end
+      end
     end
   end
 end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -469,13 +469,19 @@ module Arel
           compile(node).must_equal %(("products"."price" - 7))
         end
 
+        it "should handle Concatination" do
+          table = Table.new(:users)
+          node = table[:name].concat(table[:name])
+          compile(node).must_equal %("users"."name" || "users"."name")
+        end
+
         it "should handle arbitrary operators" do
           node = Arel::Nodes::InfixOperation.new(
-            '||',
+            '&&',
             Arel::Attributes::String.new(Table.new(:products), :name),
             Arel::Attributes::String.new(Table.new(:products), :name)
           )
-          compile(node).must_equal %("products"."name" || "products"."name")
+          compile(node).must_equal %("products"."name" && "products"."name")
         end
       end
 


### PR DESCRIPTION
Hi All

String concatenation is database specific.

Postgres (and ANSI SQL) supports `column1 || column2`, but databases like mysql use `concat(column1, column2)`.

This PR introduces string concatenation to Arel to abstract this nuance. e.g.: `table[:name].concat(other)`.
Before this, developers needed to build database specific sql on their own.

If Arel is not the right place for this abstraction, do you have any suggestions on how to abstract this in my own app?

Thanks,
Keenan

/cc @fryguy @matthewd (and of course @tenderlove ) This is for ancestry, but I feel we want something similar in our spot as well.