### PR TITLE
added Casted#hash

### DIFF
--- a/lib/arel/nodes/casted.rb
+++ b/lib/arel/nodes/casted.rb
@@ -10,6 +10,10 @@ module Arel
 
       def nil?; @val.nil?; end
 
+      def hash
+         [@class, @val, @attribute].hash
+      end
+
       def eql? other
         self.class == other.class &&
             self.val == other.val &&

--- a/test/nodes/test_casted.rb
+++ b/test/nodes/test_casted.rb
@@ -1,0 +1,16 @@
+require 'helper'
+
+module Arel
+  module Nodes
+    describe Casted do
+      describe '#hash' do
+        it 'is equal when eql? returns true' do
+          one = Casted.new 1, 2
+          also_one = Casted.new 1, 2
+
+          assert_equal one.hash, also_one.hash
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
```eql?``` was defined, but no matching ```hash``` definition 