### PR TITLE
Define table-limited star (arel_table.star)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ users.join(photos, Arel::Nodes::OuterJoin).on(users[:id].eq(photos[:user_id]))
 # => SELECT FROM users LEFT OUTER JOIN photos ON users.id = photos.user_id
 ```
 
+Star projects all columns from a table:
+
+```ruby
+users
+  .join(photos, Arel::Nodes::OuterJoin).on(users[:id].eq(photos[:user_id]))
+  .where(photos[:published].eq(true))
+  .project(users.star)
+# => SELECT "users".*
+#    FROM users LEFT OUTER JOIN photos ON users.id = photos.user_id
+#    WHERE photos.published = true
+```
+
 What are called `LIMIT` and `OFFSET` in SQL are called `take` and `skip` in Arel:
 
 ```ruby

--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -84,6 +84,10 @@ module Arel
       ::Arel::Attribute.new self, name
     end
 
+    def star
+      ::Arel.sql "\"#{name}\".*"
+    end
+
     def hash
       # Perf note: aliases and table alias is excluded from the hash
       #  aliases can have a loop back to this table breaking hashes in parent

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -179,6 +179,16 @@ module Arel
       @relation.table_name.must_equal 'users'
     end
 
+    describe 'star' do
+      it 'returns table-limited star' do
+        manager = @relation.project(@relation.star)
+        manager.to_sql.must_be_like %{
+          SELECT "users".*
+          FROM "users"
+        }
+      end
+    end
+
     describe '[]' do
       describe 'when given a Symbol' do
         it "manufactures an attribute if the symbol names an attribute within the relation" do


### PR DESCRIPTION
Why don't we have `star` method defined for the custom table:

```
users = User.arel_table
users.project(users.star).to_sql
# => 'SELECT "users".* FROM "users"'
```