### PR TITLE
Support Oracle bind parameter value for Oracle12 visitor

### DIFF
--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -48,6 +48,10 @@ module Arel
 
         super
       end
+
+      def visit_Arel_Nodes_BindParam o, collector
+        collector.add_bind(o) { |i| ":a#{i}" }
+      end
     end
   end
 end

--- a/test/visitors/test_oracle12.rb
+++ b/test/visitors/test_oracle12.rb
@@ -2,9 +2,10 @@ require 'helper'
 
 module Arel
   module Visitors
-    describe 'the oracle visitor' do
+    describe 'the oracle12 visitor' do
       before do
-        @visitor = Oracle12.new Table.engine.connection_pool
+        @visitor = Oracle12.new Table.engine.connection
+        @table = Table.new(:users)
       end
 
       def compile node
@@ -40,6 +41,16 @@ module Arel
         it 'defaults to FOR UPDATE when locking' do
           node = Nodes::Lock.new(Arel.sql('FOR UPDATE'))
           compile(node).must_be_like "FOR UPDATE"
+        end
+      end
+
+      describe "Nodes::BindParam" do
+        it "increments each bind param" do
+          query = @table[:name].eq(Arel::Nodes::BindParam.new)
+            .and(@table[:id].eq(Arel::Nodes::BindParam.new))
+          compile(query).must_be_like %{
+            "users"."name" = :a1 AND "users"."id" = :a2
+          }
         end
       end
     end


### PR DESCRIPTION
This pull request addresses following error when ActiveRecord unit test executed using Oracle 12c database. It is similar with #338 which is for Oracle visitor supporting Oracle database 11gR2 or lower version of Oracle.

```ruby
$ cd activerecord
$ bundle exec rake test_oracle
... snip ...

stmt.c:195:in oci8lib_230.so: OCIError: ORA-01036: illegal variable name/number: SELECT  "AR_INTERNAL_METADATA".* FROM "AR_INTERNAL_METADATA" ORDER BY "AR_INTERNAL_METADATA"."KEY" ASC FETCH FIRST ? ROWS ONLY (ActiveRecord::StatementInvalid)
```

- Before this pull request
```sql
 FETCH FIRST ? ROWS ONLY
```
- After this pull request
```sql
 FETCH FIRST :a1 ROWS ONLY
```

Once this pull request reviewed and merged, I wanted to backport this change to 7.0.x version of Arel.