### PR TITLE
Raise ArgumentError if limit and lock are used for Oracle12 visitor

### DIFF
--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -6,10 +6,12 @@ module Arel
       def visit_Arel_Nodes_SelectStatement o, collector
         # Oracle does not allow LIMIT clause with select for update
         if o.limit && o.lock
-          o = o.dup
-          o.limit = []
+          raise ArgumentError, <<-MSG
+            'Combination of limit and lock is not supported.
+            because generated SQL statements
+            `SELECT FOR UPDATE and FETCH FIRST n ROWS` generates ORA-02014.`
+          MSG
         end
-
         super
       end
 

--- a/test/visitors/test_oracle12.rb
+++ b/test/visitors/test_oracle12.rb
@@ -29,12 +29,13 @@ module Arel
       end
 
       describe 'locking' do
-        it 'removes limit when locking' do
+        it 'generates ArgumentError if limit and lock are used' do
           stmt = Nodes::SelectStatement.new
           stmt.limit = Nodes::Limit.new(10)
           stmt.lock = Nodes::Lock.new(Arel.sql('FOR UPDATE'))
-          sql = compile(stmt)
-          sql.must_be_like "SELECT FOR UPDATE"
+          assert_raises ArgumentError do
+            sql = compile(stmt)
+          end
         end
 
         it 'defaults to FOR UPDATE when locking' do


### PR DESCRIPTION
Considering several comments in https://github.com/rails/rails/issues/24779 and https://github.com/rails/arel/pull/337/ this pull request changes Oracle12 visitor behavior to return ArgumentError if limit and lock are used.

it would generates `SELECT ... FETCH FIRST n ROWS ONLY FOR UPDATE`
which causes Oracle 12c database returns this error :

``` sql
ORA-02014: cannot select FOR UPDATE from view with DISTINCT, GROUP BY, etc.
```

Oracle12 visitor is a new feature for Rails 5, then it would not cause large incompatibility for users.
