### PR TITLE
between accepts a pair instead of a range

### DIFF
--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -24,23 +24,27 @@ module Arel
       grouping_all :eq, quoted_array(others)
     end
 
-    def between other
-      if equals_quoted?(other.begin, -Float::INFINITY)
-        if equals_quoted?(other.end, Float::INFINITY)
-          not_in([])
-        elsif other.exclude_end?
-          lt(other.end)
-        else
-          lteq(other.end)
-        end
-      elsif equals_quoted?(other.end, Float::INFINITY)
-        gteq(other.begin)
-      elsif other.exclude_end?
-        gteq(other.begin).and(lt(other.end))
+    def between other, other2 = nil, exclude_end = false
+      #raise "here"
+      if other2.nil?
+        left, right, exclude_end = other.begin, other.end, other.exclude_end?
       else
-        left = quoted_node(other.begin)
-        right = quoted_node(other.end)
-        Nodes::Between.new(self, left.and(right))
+        left, right = other, other2
+      end
+      if equals_quoted?(left, -Float::INFINITY)
+        if equals_quoted?(right, Float::INFINITY)
+          not_in([])
+        elsif exclude_end
+          lt(right)
+        else
+          lteq(right)
+        end
+      elsif equals_quoted?(right, Float::INFINITY)
+        gteq(left)
+      elsif exclude_end
+        gteq(left).and(lt(right))
+      else
+        Nodes::Between.new(self, quoted_node(left).and(quoted_node(right)))
       end
     end
 
@@ -70,25 +74,26 @@ Passing a range to `#in` is deprecated. Call `#between`, instead.
       grouping_all :in, others
     end
 
-    def not_between other
-      if equals_quoted?(other.begin, -Float::INFINITY)
-        if equals_quoted?(other.end, Float::INFINITY)
-          self.in([])
-        elsif other.exclude_end?
-          gteq(other.end)
-        else
-          gt(other.end)
-        end
-      elsif equals_quoted?(other.end, Float::INFINITY)
-        lt(other.begin)
+    def not_between other, other2 = nil, exclude_end = false
+      if other2.nil?
+        left, right, exclude_end = other.begin, other.end, other.exclude_end?
       else
-        left = lt(other.begin)
-        right = if other.exclude_end?
-          gteq(other.end)
+        left, right = other, other2
+      end
+      if equals_quoted?(left, -Float::INFINITY)
+        if equals_quoted?(right, Float::INFINITY)
+          self.in([])
+        elsif exclude_end
+          gteq(right)
         else
-          gt(other.end)
+          gt(right)
         end
-        left.or(right)
+      elsif equals_quoted?(right, Float::INFINITY)
+        lt(left)
+      elsif exclude_end
+        lt(left).or(gteq(right))
+      else
+        lt(left).or(gt(right))
       end
     end
 

--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -572,6 +572,19 @@ module Arel
           )
         end
 
+        it 'can be constructed with a pair' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(1, 3)
+
+          node.must_equal Nodes::Between.new(
+            attribute,
+            Nodes::And.new([
+              Nodes::Casted.new(1, attribute),
+              Nodes::Casted.new(3, attribute)
+            ])
+          )
+        end
+
         it 'can be constructed with a range starting from -Infinity' do
           attribute = Attribute.new nil, nil
           node = attribute.between(-::Float::INFINITY..3)
@@ -589,6 +602,16 @@ module Arel
           node.must_equal Nodes::LessThanOrEqual.new(
             attribute,
             Nodes::Quoted.new(3)
+          )
+        end
+
+        it 'can be constructed with parameters starting from -Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(-::Float::INFINITY, 3)
+
+          node.must_equal Nodes::LessThanOrEqual.new(
+            attribute,
+            Nodes::Casted.new(3, attribute)
           )
         end
 
@@ -626,6 +649,12 @@ module Arel
           node.must_equal Nodes::NotIn.new(attribute, [])
         end
 
+        it 'can be constructed with an infinite pair' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(-::Float::INFINITY, ::Float::INFINITY)
+
+          node.must_equal Nodes::NotIn.new(attribute, [])
+        end
 
         it 'can be constructed with a range ending at Infinity' do
           attribute = Attribute.new nil, nil
@@ -647,9 +676,35 @@ module Arel
           )
         end
 
+        it 'can be constructed with a pair ending at Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(0, ::Float::INFINITY)
+
+          node.must_equal Nodes::GreaterThanOrEqual.new(
+            attribute,
+            Nodes::Casted.new(0, attribute)
+          )
+        end
+
         it 'can be constructed with an exclusive range' do
           attribute = Attribute.new nil, nil
           node = attribute.between(0...3)
+
+          node.must_equal Nodes::And.new([
+            Nodes::GreaterThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            ),
+            Nodes::LessThan.new(
+              attribute,
+              Nodes::Casted.new(3, attribute)
+            )
+          ])
+        end
+
+        it 'can be constructed with an exclusive pair' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(0, 3, true)
 
           node.must_equal Nodes::And.new([
             Nodes::GreaterThanOrEqual.new(
@@ -768,9 +823,35 @@ module Arel
           ))
         end
 
+        it 'can be constructed with a standard pair' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(1, 3)
+
+          node.must_equal Nodes::Grouping.new(Nodes::Or.new(
+            Nodes::LessThan.new(
+              attribute,
+              Nodes::Casted.new(1, attribute)
+            ),
+            Nodes::GreaterThan.new(
+              attribute,
+              Nodes::Casted.new(3, attribute)
+            )
+          ))
+        end
+
         it 'can be constructed with a range starting from -Infinity' do
           attribute = Attribute.new nil, nil
           node = attribute.not_between(-::Float::INFINITY..3)
+
+          node.must_equal Nodes::GreaterThan.new(
+            attribute,
+            Nodes::Casted.new(3, attribute)
+          )
+        end
+
+        it 'can be constructed with a pair starting from -Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(-::Float::INFINITY, 3)
 
           node.must_equal Nodes::GreaterThan.new(
             attribute,
@@ -808,6 +889,22 @@ module Arel
         it 'can be constructed with an exclusive range' do
           attribute = Attribute.new nil, nil
           node = attribute.not_between(0...3)
+
+          node.must_equal Nodes::Grouping.new(Nodes::Or.new(
+            Nodes::LessThan.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            ),
+            Nodes::GreaterThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(3, attribute)
+            )
+          ))
+        end
+
+        it 'can be constructed with an exclusive pair' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(0, 3, true)
 
           node.must_equal Nodes::Grouping.new(Nodes::Or.new(
             Nodes::LessThan.new(


### PR DESCRIPTION
Introduce `table[:column].between(table[:since], table[:till])`

3rd parameter exposes `exclude_end` which defaults to false (the same as `1..2`)

Fixes #394 
/cc @matthewd 
