### PR TITLE
Allow Grouping to be used in more places

### DIFF
--- a/lib/arel/nodes/grouping.rb
+++ b/lib/arel/nodes/grouping.rb
@@ -1,7 +1,11 @@
 module Arel
   module Nodes
     class Grouping < Unary
+      include Arel::Expressions
       include Arel::Predications
+      include Arel::AliasPredication
+      include Arel::OrderPredications
+      include Arel::Math
     end
   end
 end

--- a/test/nodes/test_grouping.rb
+++ b/test/nodes/test_grouping.rb
@@ -19,6 +19,16 @@ module Arel
           assert_equal 2, array.uniq.size
         end
       end
+
+      it 'accepts sorting' do
+        grouping = Grouping.new(Nodes.build_quoted('foo'))
+        grouping.asc.to_sql.must_be_like %q{('foo') ASC}
+      end
+
+      it 'accepts aliases' do
+        grouping = Grouping.new(Nodes.build_quoted('foo'))
+        grouping.as("bar").to_sql.must_be_like %q{('foo') AS bar}
+      end
     end
   end
 end


### PR DESCRIPTION
Allow a) nodes to be sorted by grouped columns and b) grouped columns to be aliased

This also alleviates some of the push in rails to use Arel nodes everywhere instead of using Arel helper methods.

This list of modules is from `Attribute` since `Grouping` can be used any place that an `Attribute` node can be used. Let me know if you want a different list.

This is along the lines of #433 giving a little more flexibility to nodes so people perform logic without having to create new Arel nodes everywhere. This also fixes rails/rails#24631

Thanks

/cc @matthewd this gives rails more lenient sorting
