### PR TITLE
Support for unified Integer class in Ruby 2.4+

### DIFF
--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -141,6 +141,7 @@ module Arel
       alias :visit_FalseClass                    :terminal
       alias :visit_Fixnum                        :terminal
       alias :visit_Float                         :terminal
+      alias :visit_Integer                       :terminal
       alias :visit_NilClass                      :terminal
       alias :visit_String                        :terminal
       alias :visit_Symbol                        :terminal

--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -205,6 +205,7 @@ module Arel
       alias :visit_TrueClass :visit_String
       alias :visit_FalseClass :visit_String
       alias :visit_Arel_Nodes_BindParam :visit_String
+      alias :visit_Integer :visit_String
       alias :visit_Fixnum :visit_String
       alias :visit_BigDecimal :visit_String
       alias :visit_Float :visit_String

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -762,6 +762,7 @@ module Arel
       alias :visit_Arel_Nodes_SqlLiteral :literal
       alias :visit_Bignum                :literal
       alias :visit_Fixnum                :literal
+      alias :visit_Integer               :literal
 
       def quoted o, a
         if a && a.able_to_type_cast?


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer: https://bugs.ruby-lang.org/issues/12005

Ruby ~2.3 `1234.class` is `Fixnum` and `123456789012345678901234567890.class`
is `Bignum`.
Ruby 2.4+ `1234.class` is `Integer` and `123456789012345678901234567890.class`
is `Integer`.

So what we should do is defining `visit_Integer` method to visitors.