### PR TITLE
Fix Casted#hash uninitialized @class variable

### DIFF
--- a/lib/arel/nodes/casted.rb
+++ b/lib/arel/nodes/casted.rb
@@ -11,7 +11,7 @@ module Arel
       def nil?; @val.nil?; end
 
       def hash
-         [@class, @val, @attribute].hash
+        [self.class, @val, @attribute].hash
       end
 
       def eql? other


### PR DESCRIPTION
- The hash method uses @class but it is not initialized, I think we
  meant to use @class here.
- Because of uninitialized @class variable there are so many warnings
  when Arel master or 7.1 is used with Rails and tests are run.