### PR TITLE
Adds UNION DISTINCT functionality

### DIFF
--- a/lib/arel/nodes/binary.rb
+++ b/lib/arel/nodes/binary.rb
@@ -41,6 +41,7 @@ module Arel
       Or
       Union
       UnionAll
+      UnionDistinct
       Intersect
       Except
     }.each do |name|

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -304,6 +304,11 @@ module Arel
         infix_value(o, collector, " UNION ALL ") << " )"
       end
 
+      def visit_Arel_Nodes_UnionDistinct o, collector
+        collector << "( "
+        infix_value(o, collector, " UNION DISTINCT ") << " )"
+      end
+
       def visit_Arel_Nodes_Intersect o, collector
         collector << "( "
         infix_value(o, collector, " INTERSECT ") << " )"

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -273,6 +273,13 @@ module Arel
         }
       end
 
+      it 'should union distinct' do
+        node = @m1.union :distinct, @m2
+
+        node.to_sql.must_be_like %{
+          ( SELECT * FROM "users"  WHERE "users"."age" < 18 UNION DISTINCT SELECT * FROM "users"  WHERE "users"."age" > 99 )
+        }
+      end
     end
 
     describe 'intersect' do


### PR DESCRIPTION
Adds functionality to specify `UNION DISTINCT` on a `UNION`. I arrived at the fix by following the pattern for `UNION ALL`