### PR TITLE
remove union mapping as :binary node when performing DepthFirst enumeration

### DIFF
--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -98,7 +98,6 @@ module Arel
       alias :visit_Arel_Nodes_Regexp             :binary
       alias :visit_Arel_Nodes_RightOuterJoin     :binary
       alias :visit_Arel_Nodes_TableAlias         :binary
-      alias :visit_Arel_Nodes_Union              :binary
       alias :visit_Arel_Nodes_Values             :binary
       alias :visit_Arel_Nodes_When               :binary
 

--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -834,6 +834,18 @@ module Arel
           node.must_equal Nodes::NotIn.new(attribute, mgr.ast)
         end
 
+        it 'can be constructed with a Union' do
+          relation = Table.new(:users)
+          mgr1 = relation.project(relation[:id])
+          mgr2 = relation.project(relation[:id])
+
+          union = mgr1.union(mgr2)
+          node = relation[:id].in(union)
+          node.to_sql.must_be_like %{
+            "users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))
+          }
+        end
+
         it 'can be constructed with a list' do
           attribute = Attribute.new nil, nil
           node = attribute.not_in([1, 2, 3])


### PR DESCRIPTION
When using an `in` statement on a `union` a lot of garbage ends up in the generated SQL.  There might be a chance that this line was not suppose to be checked in during [this commit](https://github.com/rails/arel/commit/b57a11cb8abfca345f63084ce841c6f412c1156e#diff-4fb8c96a9901dc6f27853baf95060c8dR90).  A reason I lean that way was another Union related change that was quickly removed after that commit [here](https://github.com/rails/arel/commit/9eb4a1c633894a367ad99e93e4e0000f7acf1e50)

cc @tenderlove maybe you have some more insights about this?