### PR TITLE
Fix invalid BindParam output in Dot visitor

### DIFF
--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -204,13 +204,14 @@ module Arel
       alias :visit_NilClass :visit_String
       alias :visit_TrueClass :visit_String
       alias :visit_FalseClass :visit_String
-      alias :visit_Arel_Nodes_BindParam :visit_String
       alias :visit_Integer :visit_String
       alias :visit_Fixnum :visit_String
       alias :visit_BigDecimal :visit_String
       alias :visit_Float :visit_String
       alias :visit_Symbol :visit_String
       alias :visit_Arel_Nodes_SqlLiteral :visit_String
+
+      def visit_Arel_Nodes_BindParam o; end
 
       def visit_Hash o
         o.each_with_index do |pair, i|

--- a/test/visitors/test_dot.rb
+++ b/test/visitors/test_dot.rb
@@ -70,6 +70,12 @@ module Arel
           @visitor.accept binary, Collectors::PlainString.new
         end
       end
+
+      def test_Arel_Nodes_BindParam
+        node = Arel::Nodes::BindParam.new
+        collector = Collectors::PlainString.new
+        assert_match '[label="<f0>Arel::Nodes::BindParam"]', @visitor.accept(node, collector).value
+      end
     end
   end
 end


### PR DESCRIPTION
Since BindParam has no value, treating it like a string causes it to fallback to `Object#to_s`, leading to output like `#<Arel::Nodes::BindParam:0x007fa43c866108>`.

Since angle brackets are significant in Dot labels, this causes `Error: bad label format` when passing the graph into dot.

I've changed `visit_Arel_Nodes_BindParam` to a noop, which solves the problem.