### PR TITLE
Add Arel::Nodes::Casted to dot visitor

### DIFF
--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -155,6 +155,11 @@ module Arel
         visit_edge o, "name"
       end
 
+      def visit_Arel_Nodes_Casted o
+        visit_edge o, 'val'
+        visit_edge o, 'attribute'
+      end
+
       def visit_Arel_Attribute o
         visit_edge o, "relation"
         visit_edge o, "name"

--- a/test/visitors/test_dot.rb
+++ b/test/visitors/test_dot.rb
@@ -64,6 +64,7 @@ module Arel
         Arel::Nodes::As,
         Arel::Nodes::DeleteStatement,
         Arel::Nodes::JoinSource,
+        Arel::Nodes::Casted,
       ].each do |klass|
         define_method("test_#{klass.name.gsub('::', '_')}") do
           binary = klass.new(:a, :b)


### PR DESCRIPTION
Adds casted node to the dot visitor with outgoing edges to val and
attribute.
<img width="1123" alt="casted-node" src="https://cloud.githubusercontent.com/assets/459462/18027489/0528fa0a-6c65-11e6-87ea-da563b11b38e.png">

Fixes #419