### PR TITLE
use #data_source_exists? if possible instead of deprecated #table_exi…

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -171,7 +171,7 @@ module Arel
       end
 
       def table_exists? name
-        schema_cache.table_exists? name
+        schema_cache.data_source_exists?(name)
       end
 
       def column_for attr

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -39,7 +39,7 @@ module FakeRecord
       @primary_keys[name.to_s]
     end
 
-    def table_exists? name
+    def data_source_exists? name
       @tables.include? name.to_s
     end
 


### PR DESCRIPTION
Using of arel raise `DEPRECATION WARNING: table_exists? is deprecated and will be removed from Rails 5.1 (use #data_source_exists? instead)` in our project with rails 5.0.0.1