### PR TITLE
Freeze all the strings in visitors

### DIFF
--- a/lib/arel/visitors/bind_visitor.rb
+++ b/lib/arel/visitors/bind_visitor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     module BindVisitor

--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class Dot < Arel::Visitors::Visitor
@@ -272,7 +273,7 @@ module Arel
             label = "<f0>#{node.name}"
 
             node.fields.each_with_index do |field, i|
-              label << "|<f#{i + 1}>#{quote field}"
+              label += "|<f#{i + 1}>#{quote field}"
             end
 
             "#{node.id} [label=\"#{label}\"];"

--- a/lib/arel/visitors/ibm_db.rb
+++ b/lib/arel/visitors/ibm_db.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class IBM_DB < Arel::Visitors::ToSql

--- a/lib/arel/visitors/informix.rb
+++ b/lib/arel/visitors/informix.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class Informix < Arel::Visitors::ToSql

--- a/lib/arel/visitors/mssql.rb
+++ b/lib/arel/visitors/mssql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class MSSQL < Arel::Visitors::ToSql

--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class MySQL < Arel::Visitors::ToSql

--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class Oracle < Arel::Visitors::ToSql
@@ -125,7 +126,7 @@ module Arel
             array[i] << ',' << part
           else
             # to ensure that array[i] will be String and not Arel::Nodes::SqlLiteral
-            array[i] = '' << part
+            array[i] = part.to_s
           end
           i += 1 if array[i].count('(') == array[i].count(')')
         end

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class Oracle12 < Arel::Visitors::ToSql

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql

--- a/lib/arel/visitors/sqlite.rb
+++ b/lib/arel/visitors/sqlite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class SQLite < Arel::Visitors::ToSql

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bigdecimal'
 require 'date'
 require 'arel/visitors/reduce'

--- a/lib/arel/visitors/where_sql.rb
+++ b/lib/arel/visitors/where_sql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class WhereSql < Arel::Visitors::ToSql

--- a/test/visitors/test_oracle12.rb
+++ b/test/visitors/test_oracle12.rb
@@ -35,7 +35,7 @@ module Arel
           stmt.limit = Nodes::Limit.new(10)
           stmt.lock = Nodes::Lock.new(Arel.sql('FOR UPDATE'))
           assert_raises ArgumentError do
-            sql = compile(stmt)
+            compile(stmt)
           end
         end
 


### PR DESCRIPTION
There is a bunch of strings (`' WHERE ', ', ', ' GROUP BY '`, you name it) that are extensively used in visitors and are constant, we can save a bunch of allocations if they will be frozen.
