### PR TITLE
Introduce Expression Node

### DIFF
--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # node
 require 'arel/nodes/node'
+require 'arel/nodes/node_expression'
 require 'arel/nodes/select_statement'
 require 'arel/nodes/select_core'
 require 'arel/nodes/insert_statement'

--- a/lib/arel/nodes/binary.rb
+++ b/lib/arel/nodes/binary.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class Binary < Arel::Nodes::Node
+    class Binary < Arel::Nodes::NodeExpression
       attr_accessor :left, :right
 
       def initialize left, right

--- a/lib/arel/nodes/case.rb
+++ b/lib/arel/nodes/case.rb
@@ -2,10 +2,6 @@
 module Arel
   module Nodes
     class Case < Arel::Nodes::Node
-      include Arel::OrderPredications
-      include Arel::Predications
-      include Arel::AliasPredication
-
       attr_accessor :case, :conditions, :default
 
       def initialize expression = nil, default = nil

--- a/lib/arel/nodes/casted.rb
+++ b/lib/arel/nodes/casted.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class Casted < Arel::Nodes::Node # :nodoc:
+    class Casted < Arel::Nodes::NodeExpression # :nodoc:
       attr_reader :val, :attribute
       def initialize val, attribute
         @val       = val

--- a/lib/arel/nodes/delete_statement.rb
+++ b/lib/arel/nodes/delete_statement.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class DeleteStatement < Arel::Nodes::Binary
+    class DeleteStatement < Arel::Nodes::Node
+      attr_accessor :left, :right
       attr_accessor :limit
 
       alias :relation :left
@@ -10,13 +11,27 @@ module Arel
       alias :wheres= :right=
 
       def initialize relation = nil, wheres = []
-        super
+        super()
+        @left = relation
+        @right = wheres
       end
 
       def initialize_copy other
         super
-        @right = @right.clone
+        @left  = @left.clone if @left
+        @right = @right.clone if @right
       end
+
+      def hash
+        [self.class, @left, @right].hash
+      end
+
+      def eql? other
+        self.class == other.class &&
+          self.left == other.left &&
+          self.right == other.right
+      end
+      alias :== :eql?
     end
   end
 end

--- a/lib/arel/nodes/extract.rb
+++ b/lib/arel/nodes/extract.rb
@@ -2,9 +2,6 @@
 module Arel
   module Nodes
     class Extract < Arel::Nodes::Unary
-      include Arel::AliasPredication
-      include Arel::Predications
-
       attr_accessor :field
 
       def initialize expr, field

--- a/lib/arel/nodes/false.rb
+++ b/lib/arel/nodes/false.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class False < Arel::Nodes::Node
+    class False < Arel::Nodes::NodeExpression
       def hash
         self.class.hash
       end

--- a/lib/arel/nodes/function.rb
+++ b/lib/arel/nodes/function.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class Function < Arel::Nodes::Node
-      include Arel::Predications
+    class Function < Arel::Nodes::NodeExpression
       include Arel::WindowPredications
-      include Arel::OrderPredications
       attr_accessor :expressions, :alias, :distinct
 
       def initialize expr, aliaz = nil

--- a/lib/arel/nodes/grouping.rb
+++ b/lib/arel/nodes/grouping.rb
@@ -2,7 +2,6 @@
 module Arel
   module Nodes
     class Grouping < Unary
-      include Arel::Predications
     end
   end
 end

--- a/lib/arel/nodes/node_expression.rb
+++ b/lib/arel/nodes/node_expression.rb
@@ -1,0 +1,11 @@
+module Arel
+  module Nodes
+    class NodeExpression < Arel::Nodes::Node
+      include Arel::Expressions
+      include Arel::Predications
+      include Arel::AliasPredication
+      include Arel::OrderPredications
+      include Arel::Math
+    end
+  end
+end

--- a/lib/arel/nodes/select_statement.rb
+++ b/lib/arel/nodes/select_statement.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class SelectStatement < Arel::Nodes::Node
+    class SelectStatement < Arel::Nodes::NodeExpression
       attr_reader :cores
       attr_accessor :limit, :orders, :lock, :offset, :with
 

--- a/lib/arel/nodes/terminal.rb
+++ b/lib/arel/nodes/terminal.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class Distinct < Arel::Nodes::Node
+    class Distinct < Arel::Nodes::NodeExpression
       def hash
         self.class.hash
       end

--- a/lib/arel/nodes/true.rb
+++ b/lib/arel/nodes/true.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class True < Arel::Nodes::Node
+    class True < Arel::Nodes::NodeExpression
       def hash
         self.class.hash
       end

--- a/lib/arel/nodes/unary.rb
+++ b/lib/arel/nodes/unary.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Arel
   module Nodes
-    class Unary < Arel::Nodes::Node
+    class Unary < Arel::Nodes::NodeExpression
       attr_accessor :expr
       alias :value :expr
 

--- a/lib/arel/nodes/unary_operation.rb
+++ b/lib/arel/nodes/unary_operation.rb
@@ -3,12 +3,6 @@ module Arel
   module Nodes
 
     class UnaryOperation < Unary
-      include Arel::Expressions
-      include Arel::Predications
-      include Arel::OrderPredications
-      include Arel::AliasPredication
-      include Arel::Math
-
       attr_reader :operator
 
       def initialize operator, operand

--- a/test/test_nodes.rb
+++ b/test/test_nodes.rb
@@ -12,6 +12,7 @@ module Arel
           node_descendants.unshift k unless k == self
         end
         node_descendants.delete(Arel::Nodes::Node)
+        node_descendants.delete(Arel::Nodes::NodeExpression)
 
         bad_node_descendants = node_descendants.reject do |subnode|
           eqeq_owner = subnode.instance_method(:==).owner


### PR DESCRIPTION
This is a followup to #435 

This strives to alleviate the inconsistencies in the arel interface:

> `select(arel_table[:name])` works but `select(arel_table[:name].lower)` does not.
> 
> Or `arel_table[:name].asc` works but `arel_table[:name].lower.asc` does not.

Many nodes can be used in places that are not currently characterized by the current `Arel::Node`. This introduces these common nodes in a way that makes it easier for rails to use common shortcut methods like `desc`, `lower` or other common methods.

``` SQL
SELECT "users"."id", "users"."name"
FROM "users"
ORDER BY LOWER(CASE "users"."address" IS NULL then "A" else "users"."address") DESC
```

(yes, this is not the sql I would have written, but I was trying to generate sql that I could imagine generating through rails)

Thanks again for being so helpful extending rails and `Arel` to the many needs of your users.
