### PR TITLE
Use Arel::Nodes::BindParam in Oracle visitor for queries using both LIMIT and OFFSET

### DIFF
--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -124,6 +124,21 @@ module Arel
             }
           end
 
+          it 'creates a subquery when there is limit and offset with BindParams' do
+            stmt = Nodes::SelectStatement.new
+            stmt.limit = Nodes::Limit.new(Nodes::BindParam.new)
+            stmt.offset = Nodes::Offset.new(Nodes::BindParam.new)
+            sql = compile stmt
+            sql.must_be_like %{
+              SELECT * FROM (
+                SELECT raw_sql_.*, rownum raw_rnum_
+                FROM (SELECT ) raw_sql_
+                 WHERE rownum <= (:a1 + :a2)
+              )
+              WHERE raw_rnum_ > :a1
+            }
+          end
+
           it 'is idempotent with different subquery' do
             stmt = Nodes::SelectStatement.new
             stmt.limit = Nodes::Limit.new(10)
@@ -148,7 +163,6 @@ module Arel
             }
           end
         end
-
       end
 
       it 'modified except to be minus' do


### PR DESCRIPTION
This is to fix #438, where the Oracle visitor is raising an undefined method error when trying to calculate the limit for queries specifying both limit and offset.

Since [this commit](https://github.com/rails/rails/commit/574f255629a45cd67babcfb9bb8e163e091a53b8#diff-bf6dd6226db3aab589916f09236881c7R959), ActiveModel now uses BindParams to pass limit and offset parameters to Arel, so it now isn't able to calculate the limit directly.

In this fix, when a BindParam object is passed to `visit_Arel_Nodes_SelectStatement`, it now will use this binding instead of calculating the values. The previous behaviour remains when the offset expression is not a BindParam object.