### PR TITLE
Fix Build: Allow failures from rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-2
 bundler_args: --jobs 3 --retry 3
 notifications:
   email: false


### PR DESCRIPTION
All PRs since September have been failing on rbx

It looks like rvm is having trouble installing rubinius

```
rvm use rbx-2 --install --binary --fuzzy
```

Tried with `rbx` and `rbx-3` but neither of those worked.

Trying to follow through https://github.com/travis-ci/travis-ci/issues/5294 and find a way to fix this build.

Would prefer not to disable this, but have run out of ideas. Any other suggestions to try?