### PR TITLE
SQL Literals should not be type casted

### DIFF
--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -96,6 +96,7 @@ module Arel
     alias :== :eql?
 
     def type_cast_for_database(attribute_name, value)
+      return value if value.is_a? Arel::Nodes::SqlLiteral
       type_caster.type_cast_for_database(attribute_name, value)
     end
 

--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -997,6 +997,14 @@ module Arel
         condition.to_sql.must_equal %("foo"."id" = 1 AND "foo"."other_id" = '2')
       end
 
+      it 'does not attempt to type cast SqlLiteral' do
+        table = Table.new(:foo, type_caster: Object.new)
+        sql_literal = Arel::Nodes::SqlLiteral.new('bar')
+
+        condition = table["id"].eq(sql_literal)
+        condition.to_sql.must_equal %("foo"."id" = bar)
+      end
+
       it 'falls back to using the connection adapter for type casting' do
         table = Table.new(:users)
         condition = table["id"].eq("1")


### PR DESCRIPTION
The issue makes itself apparent when querying integer colums, which will call `#to_i` on the SqlLiteral. Take the following example:

```ruby
Post.arel_table[:id].eq(Arel.sql('coalesce(1, 0)')).to_sql
```

Active Record 4.2:

```sql
"posts"."id" = coalesce(1, 0)
```

Active Record 5.0:

```sql
"posts"."id" = 0
```

Related: https://github.com/rails/rails/pull/26992