### PR TITLE
Allowing between to use more flexible unboudned ranges

### DIFF
--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -619,6 +619,13 @@ module Arel
           node.must_equal Nodes::NotIn.new(attribute, [])
         end
 
+        it 'can be constructed with an infinite range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(-::DateTime::Infinity.new..::DateTime::Infinity.new)
+
+          node.must_equal Nodes::NotIn.new(attribute, [])
+        end
+
         it 'can be constructed with a quoted infinite range' do
           attribute = Attribute.new nil, nil
           node = attribute.between(quoted_range(-::Float::INFINITY, ::Float::INFINITY, false))
@@ -626,6 +633,12 @@ module Arel
           node.must_equal Nodes::NotIn.new(attribute, [])
         end
 
+        it 'can be constructed with a quoted infinite date range' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(quoted_range(-::DateTime::Infinity.new, ::DateTime::Infinity.new, false))
+
+          node.must_equal Nodes::NotIn.new(attribute, [])
+        end
 
         it 'can be constructed with a range ending at Infinity' do
           attribute = Attribute.new nil, nil
@@ -637,6 +650,16 @@ module Arel
           )
         end
 
+        it 'can be constructed with a range ending at DateTime::Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(::Time.at(1234).to_datetime..::DateTime::Infinity.new)
+
+          node.must_equal Nodes::GreaterThanOrEqual.new(
+            attribute,
+            Nodes::Casted.new(::Time.at(1234).to_datetime, attribute)
+          )
+        end
+
         it 'can be constructed with a quoted range ending at Infinity' do
           attribute = Attribute.new nil, nil
           node = attribute.between(quoted_range(0, ::Float::INFINITY, false))
@@ -644,6 +667,16 @@ module Arel
           node.must_equal Nodes::GreaterThanOrEqual.new(
             attribute,
             Nodes::Quoted.new(0)
+          )
+        end
+
+        it 'can be constructed with a quoted range ending at DateTime::Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(quoted_range(::Time.at(1234).to_datetime, ::DateTime::Infinity.new, false))
+
+          node.must_equal Nodes::GreaterThanOrEqual.new(
+            attribute,
+            Nodes::Quoted.new(::Time.at(1234).to_datetime)
           )
         end
 
@@ -802,6 +835,16 @@ module Arel
           node.must_equal Nodes::LessThan.new(
             attribute,
             Nodes::Casted.new(0, attribute)
+          )
+        end
+
+        it 'can be constructed with a range ending at DateTime::Infinity' do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(::Time.at(1234).to_datetime..::DateTime::Infinity.new)
+
+          node.must_equal Nodes::LessThan.new(
+            attribute,
+            Nodes::Casted.new(::Time.at(1234).to_datetime, attribute)
           )
         end
 


### PR DESCRIPTION
This PR provides a more flexible implementation of the unbounded range between comparison.

The specific need that drove this change was the ability to compare unbounded date ranges, using rails this meant `where(created_at: Time.now...DateTime::Infinity.new)`

I've duplicated all the Float::INFINITY specs with a DateTime::Infinity, however the -DateTime::Infinity tests are only valid for `-DateTime::Infinity.new..DateTime::Infinity.new` This is because -`DateTime::Infinity.new..DateTime.now` throws "ArgumentError: bad value for range". I've identified the issues causing this to be, what appears to be, and incomplete implementation of `<=>` in DateTime::Infinity. I've monkey patched this locally and will see about an upstream change, then add tests for it here.