### PR TITLE
Address `Use assert_nil if expecting nil` warnings

### DIFF
--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -1198,7 +1198,7 @@ module Arel
         manager.ast.cores.last.set_quantifier.class.must_equal Arel::Nodes::Distinct
 
         manager.distinct(false)
-        manager.ast.cores.last.set_quantifier.must_equal nil
+        manager.ast.cores.last.set_quantifier.must_be_nil
       end
 
       it "chains" do
@@ -1217,7 +1217,7 @@ module Arel
         manager.ast.cores.last.set_quantifier.must_equal Arel::Nodes::DistinctOn.new(table['id'])
 
         manager.distinct_on(false)
-        manager.ast.cores.last.set_quantifier.must_equal nil
+        manager.ast.cores.last.set_quantifier.must_be_nil
       end
 
       it "chains" do


### PR DESCRIPTION
This pull request suppresses  `Use assert_nil if expecting nil` warnings.

#### Environment
* Arel master branch
* ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
* minitest (5.10.1)

#### Steps to reproduce:
```ruby
$ bundle exec ruby -w -I"lib:lib:test" test/test_select_manager.rb
Run options: --seed 11993

# Running:

.........................................................Use assert_nil if expecting nil from /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
................................................Use assert_nil if expecting nil from /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
.......

Finished in 0.048920s, 2289.4336 runs/s, 2820.9093 assertions/s.

112 runs, 138 assertions, 0 failures, 0 errors, 0 skips
$
```

