### PR TITLE
patch for threadsafe rescue and redefine of NoMethodError

### DIFF
--- a/lib/arel/visitors/reduce.rb
+++ b/lib/arel/visitors/reduce.rb
@@ -3,22 +3,26 @@ require 'arel/visitors/visitor'
 module Arel
   module Visitors
     class Reduce < Arel::Visitors::Visitor
+
       def accept object, collector
         visit object, collector
       end
 
       private
 
-      def visit object, collector
+      def dispatch_method(object, collector)
         send dispatch[object.class], object, collector
+      end
+
+      def visit object, collector
+        dispatch_method(object, collector)
       rescue NoMethodError => e
-        raise e if respond_to?(dispatch[object.class], true)
         superklass = object.class.ancestors.find { |klass|
           respond_to?(dispatch[klass], true)
         }
         raise(TypeError, "Cannot visit #{object.class}") unless superklass
         dispatch[object.class] = dispatch[superklass]
-        retry
+        dispatch_method(object, collector)
       end
     end
   end

--- a/lib/arel/visitors/visitor.rb
+++ b/lib/arel/visitors/visitor.rb
@@ -41,7 +41,11 @@ module Arel
         end
 
         if respond_to?(dispatch[object.class], true)
-          retry
+          begin
+            send dispatch[object.class], object
+          rescue NoMethodError => e2
+            raise e2
+          end
         else
           raise e
         end

--- a/lib/arel/visitors/visitor.rb
+++ b/lib/arel/visitors/visitor.rb
@@ -1,7 +1,6 @@
 module Arel
   module Visitors
     class Visitor
-      NO_METHOD_MUTEX = ::Mutex.new
 
       def initialize
         @dispatch = get_dispatch_cache
@@ -38,11 +37,7 @@ module Arel
           respond_to?(dispatch[klass], true)
         }
         raise(TypeError, "Cannot visit #{object.class}") unless superklass
-
-        NO_METHOD_MUTEX.synchronize do
-          dispatch[object.class] = dispatch[superklass] unless respond_to?(dispatch[object.class], true)
-        end
-
+        dispatch[object.class] = dispatch[superklass]
         dispatch_method(object)
       end
     end

--- a/lib/arel/visitors/visitor.rb
+++ b/lib/arel/visitors/visitor.rb
@@ -27,28 +27,23 @@ module Arel
         @dispatch
       end
 
-      def visit object
+      def dispatch_method(object)
         send dispatch[object.class], object
+      end
+
+      def visit object
+        dispatch_method(object)
       rescue NoMethodError => e
         superklass = object.class.ancestors.find { |klass|
           respond_to?(dispatch[klass], true)
         }
-
         raise(TypeError, "Cannot visit #{object.class}") unless superklass
 
         NO_METHOD_MUTEX.synchronize do
           dispatch[object.class] = dispatch[superklass] unless respond_to?(dispatch[object.class], true)
         end
 
-        if respond_to?(dispatch[object.class], true)
-          begin
-            send dispatch[object.class], object
-          rescue NoMethodError => e2
-            raise e2
-          end
-        else
-          raise e
-        end
+        dispatch_method(object)
       end
     end
   end

--- a/test/visitors/test_dispatch_contamination.rb
+++ b/test/visitors/test_dispatch_contamination.rb
@@ -3,6 +3,12 @@ require 'helper'
 module Arel
   module Visitors
     describe 'avoiding contamination between visitor dispatch tables' do
+      Collector = Struct.new(:calls) do
+        def call object
+          calls << object
+        end
+      end
+
       before do
         @connection = Table.engine.connection
         @table = Table.new(:users)
@@ -16,6 +22,19 @@ module Arel
 
         assert_equal "( TRUE UNION FALSE )", node.to_sql
       end
+
+      it "throws a legitimate NoMethodError when cannot fail upwards" do
+        @collector = Collector.new []
+        @visitor = Visitors::DepthFirst.new @collector
+        raises_exception = lambda { |_| raise NoMethodError.new }
+
+        @visitor.stub :dispatch_method, raises_exception do
+          assert_raises NoMethodError do
+            @visitor.accept ::Arel::Nodes::Not.new(:a)
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
I don't know if this the "correct" way to resolve this problem, but the issue referenced below have been experienced on our platform as well (in a Jruby, multi-threaded application)

https://github.com/rails/rails/issues/26571
https://github.com/jruby/activerecord-jdbc-adapter/issues/739

when we apply the patch we no longer experience the issue

Hoping this PR can help stimulate conversation as to the "correct" way to make the rescue and call to `dispatch[object.class] =` threadsafe