### PR TITLE
Raise custom error on empty join

### DIFF
--- a/lib/arel.rb
+++ b/lib/arel.rb
@@ -1,3 +1,5 @@
+require 'arel/errors'
+
 require 'arel/crud'
 require 'arel/factory_methods'
 

--- a/lib/arel/errors.rb
+++ b/lib/arel/errors.rb
@@ -1,0 +1,7 @@
+module Arel
+  class ArelError < StandardError
+  end
+
+  class EmptyJoinError < ArelError
+  end
+end

--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -106,7 +106,7 @@ module Arel
 
       case relation
       when String, Nodes::SqlLiteral
-        raise if relation.empty?
+        raise EmptyJoinError if relation.empty?
         klass = Nodes::StringJoin
       end
 

--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -37,7 +37,7 @@ module Arel
 
       case relation
       when String, Nodes::SqlLiteral
-        raise if relation.empty?
+        raise EmptyJoinError if relation.empty?
         klass = Nodes::StringJoin
       end
 

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -618,6 +618,16 @@ module Arel
         manager   = Arel::SelectManager.new
         manager.join(nil).must_equal manager
       end
+
+      it 'raises EmptyJoinError on empty' do
+        left      = Table.new :users
+        manager   = Arel::SelectManager.new
+
+        manager.from left
+        assert_raises(EmptyJoinError) do
+          manager.join("")
+        end
+      end
     end
 
     describe 'outer join' do

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -71,6 +71,12 @@ module Arel
           mgr.to_sql.must_be_like %{ SELECT FROM "users" }
         end
 
+        it 'raises EmptyJoinError on empty' do
+          assert_raises(EmptyJoinError) do
+            @relation.join ""
+          end
+        end
+
         it 'takes a second argument for join type' do
           right     = @relation.alias
           predicate = @relation[:id].eq(right[:id])


### PR DESCRIPTION
Raising a specific error seems more helpful