### PR TITLE
named functions compared to nil

### DIFF
--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -61,6 +61,12 @@ module Arel
         sql.must_be_like %{ omg(*) = 2 }
       end
 
+      it 'should handle nil with named functions' do
+        function = Nodes::NamedFunction.new('omg', [Arel.star])
+        sql = compile(function.eq(nil))
+        sql.must_be_like %{ omg(*) IS NULL }
+      end
+
       it 'should visit built-in functions' do
         function = Nodes::Count.new([Arel.star])
         assert_equal 'COUNT(*)', compile(function)


### PR DESCRIPTION
Using Arel `v6.0.4`
Testing equality on named function produce wrong SQL code if tested value is nil.

Nodes::NamedFunction.new('omg', [Arel.star]).eq(nil)
=> omg(*) = NULL

On master branch, there is no problem with named functions since `nil?` [has been overridden](/rails/arel/blob/d6af2090b16f7d061aa43913d610c6fada58b7e2/lib/arel/nodes/casted.rb#L11)...