### PR TITLE
Enable frozen_string_literal in all files in arel

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+AllCops:
+  DisabledByDefault: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org/"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/arel.gemspec
+++ b/arel.gemspec
@@ -1,4 +1,5 @@
 # # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
 require "arel"
 

--- a/arel.gemspec.erb
+++ b/arel.gemspec.erb
@@ -1,4 +1,5 @@
 # # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
 require "arel"
 

--- a/lib/arel.rb
+++ b/lib/arel.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arel/errors'
 
 require 'arel/crud'

--- a/lib/arel/alias_predication.rb
+++ b/lib/arel/alias_predication.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module AliasPredication
     def as other

--- a/lib/arel/attributes.rb
+++ b/lib/arel/attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arel/attributes/attribute'
 
 module Arel

--- a/lib/arel/attributes/attribute.rb
+++ b/lib/arel/attributes/attribute.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Attributes
     class Attribute < Struct.new :relation, :name

--- a/lib/arel/collectors/bind.rb
+++ b/lib/arel/collectors/bind.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Collectors
     class Bind

--- a/lib/arel/collectors/plain_string.rb
+++ b/lib/arel/collectors/plain_string.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 module Arel
   module Collectors
     class PlainString
       def initialize
-        @str = ''
+        @str = ''.dup
       end
 
       def value

--- a/lib/arel/collectors/sql_string.rb
+++ b/lib/arel/collectors/sql_string.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'arel/collectors/plain_string'
 

--- a/lib/arel/compatibility/wheres.rb
+++ b/lib/arel/compatibility/wheres.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Compatibility # :nodoc:
     class Wheres # :nodoc:

--- a/lib/arel/crud.rb
+++ b/lib/arel/crud.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   ###
   # FIXME hopefully we can remove this

--- a/lib/arel/delete_manager.rb
+++ b/lib/arel/delete_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   class DeleteManager < Arel::TreeManager
     def initialize

--- a/lib/arel/errors.rb
+++ b/lib/arel/errors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   class ArelError < StandardError
   end

--- a/lib/arel/expressions.rb
+++ b/lib/arel/expressions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Expressions
     def count distinct = false

--- a/lib/arel/factory_methods.rb
+++ b/lib/arel/factory_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   ###
   # Methods for creating various nodes

--- a/lib/arel/insert_manager.rb
+++ b/lib/arel/insert_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   class InsertManager < Arel::TreeManager
     def initialize

--- a/lib/arel/math.rb
+++ b/lib/arel/math.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Math
     def *(other)

--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # node
 require 'arel/nodes/node'
 require 'arel/nodes/select_statement'

--- a/lib/arel/nodes/and.rb
+++ b/lib/arel/nodes/and.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class And < Arel::Nodes::Node

--- a/lib/arel/nodes/ascending.rb
+++ b/lib/arel/nodes/ascending.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Ascending < Ordering

--- a/lib/arel/nodes/binary.rb
+++ b/lib/arel/nodes/binary.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Binary < Arel::Nodes::Node

--- a/lib/arel/nodes/bind_param.rb
+++ b/lib/arel/nodes/bind_param.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class BindParam < Node

--- a/lib/arel/nodes/case.rb
+++ b/lib/arel/nodes/case.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Case < Arel::Nodes::Node

--- a/lib/arel/nodes/casted.rb
+++ b/lib/arel/nodes/casted.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Casted < Arel::Nodes::Node # :nodoc:

--- a/lib/arel/nodes/count.rb
+++ b/lib/arel/nodes/count.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Count < Arel::Nodes::Function

--- a/lib/arel/nodes/delete_statement.rb
+++ b/lib/arel/nodes/delete_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class DeleteStatement < Arel::Nodes::Binary

--- a/lib/arel/nodes/descending.rb
+++ b/lib/arel/nodes/descending.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Descending < Ordering

--- a/lib/arel/nodes/equality.rb
+++ b/lib/arel/nodes/equality.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Equality < Arel::Nodes::Binary

--- a/lib/arel/nodes/extract.rb
+++ b/lib/arel/nodes/extract.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Extract < Arel::Nodes::Unary

--- a/lib/arel/nodes/false.rb
+++ b/lib/arel/nodes/false.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class False < Arel::Nodes::Node

--- a/lib/arel/nodes/full_outer_join.rb
+++ b/lib/arel/nodes/full_outer_join.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class FullOuterJoin < Arel::Nodes::Join

--- a/lib/arel/nodes/function.rb
+++ b/lib/arel/nodes/function.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Function < Arel::Nodes::Node

--- a/lib/arel/nodes/grouping.rb
+++ b/lib/arel/nodes/grouping.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Grouping < Unary

--- a/lib/arel/nodes/in.rb
+++ b/lib/arel/nodes/in.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class In < Equality

--- a/lib/arel/nodes/infix_operation.rb
+++ b/lib/arel/nodes/infix_operation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
 

--- a/lib/arel/nodes/inner_join.rb
+++ b/lib/arel/nodes/inner_join.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class InnerJoin < Arel::Nodes::Join

--- a/lib/arel/nodes/insert_statement.rb
+++ b/lib/arel/nodes/insert_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class InsertStatement < Arel::Nodes::Node

--- a/lib/arel/nodes/join_source.rb
+++ b/lib/arel/nodes/join_source.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     ###

--- a/lib/arel/nodes/matches.rb
+++ b/lib/arel/nodes/matches.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Matches < Binary

--- a/lib/arel/nodes/named_function.rb
+++ b/lib/arel/nodes/named_function.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class NamedFunction < Arel::Nodes::Function

--- a/lib/arel/nodes/node.rb
+++ b/lib/arel/nodes/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arel/collectors/sql_string'
 
 module Arel

--- a/lib/arel/nodes/outer_join.rb
+++ b/lib/arel/nodes/outer_join.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class OuterJoin < Arel::Nodes::Join

--- a/lib/arel/nodes/over.rb
+++ b/lib/arel/nodes/over.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
 

--- a/lib/arel/nodes/regexp.rb
+++ b/lib/arel/nodes/regexp.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Regexp < Binary

--- a/lib/arel/nodes/right_outer_join.rb
+++ b/lib/arel/nodes/right_outer_join.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class RightOuterJoin < Arel::Nodes::Join

--- a/lib/arel/nodes/select_core.rb
+++ b/lib/arel/nodes/select_core.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class SelectCore < Arel::Nodes::Node

--- a/lib/arel/nodes/select_statement.rb
+++ b/lib/arel/nodes/select_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class SelectStatement < Arel::Nodes::Node

--- a/lib/arel/nodes/sql_literal.rb
+++ b/lib/arel/nodes/sql_literal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class SqlLiteral < String

--- a/lib/arel/nodes/string_join.rb
+++ b/lib/arel/nodes/string_join.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class StringJoin < Arel::Nodes::Join

--- a/lib/arel/nodes/table_alias.rb
+++ b/lib/arel/nodes/table_alias.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class TableAlias < Arel::Nodes::Binary

--- a/lib/arel/nodes/terminal.rb
+++ b/lib/arel/nodes/terminal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Distinct < Arel::Nodes::Node

--- a/lib/arel/nodes/true.rb
+++ b/lib/arel/nodes/true.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class True < Arel::Nodes::Node

--- a/lib/arel/nodes/unary.rb
+++ b/lib/arel/nodes/unary.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Unary < Arel::Nodes::Node

--- a/lib/arel/nodes/unary_operation.rb
+++ b/lib/arel/nodes/unary_operation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
 

--- a/lib/arel/nodes/unqualified_column.rb
+++ b/lib/arel/nodes/unqualified_column.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class UnqualifiedColumn < Arel::Nodes::Unary

--- a/lib/arel/nodes/update_statement.rb
+++ b/lib/arel/nodes/update_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class UpdateStatement < Arel::Nodes::Node

--- a/lib/arel/nodes/values.rb
+++ b/lib/arel/nodes/values.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Values < Arel::Nodes::Binary

--- a/lib/arel/nodes/window.rb
+++ b/lib/arel/nodes/window.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class Window < Arel::Nodes::Node

--- a/lib/arel/nodes/with.rb
+++ b/lib/arel/nodes/with.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Nodes
     class With < Arel::Nodes::Unary

--- a/lib/arel/order_predications.rb
+++ b/lib/arel/order_predications.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module OrderPredications
 

--- a/lib/arel/predications.rb
+++ b/lib/arel/predications.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Predications
     def not_eq other

--- a/lib/arel/select_manager.rb
+++ b/lib/arel/select_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arel/collectors/sql_string'
 
 module Arel

--- a/lib/arel/table.rb
+++ b/lib/arel/table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   class Table
     include Arel::Crud

--- a/lib/arel/tree_manager.rb
+++ b/lib/arel/tree_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arel/collectors/sql_string'
 
 module Arel

--- a/lib/arel/update_manager.rb
+++ b/lib/arel/update_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   class UpdateManager < Arel::TreeManager
     def initialize

--- a/lib/arel/visitors.rb
+++ b/lib/arel/visitors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arel/visitors/visitor'
 require 'arel/visitors/depth_first'
 require 'arel/visitors/to_sql'

--- a/lib/arel/visitors/bind_substitute.rb
+++ b/lib/arel/visitors/bind_substitute.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class BindSubstitute

--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class DepthFirst < Arel::Visitors::Visitor

--- a/lib/arel/visitors/reduce.rb
+++ b/lib/arel/visitors/reduce.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arel/visitors/visitor'
 
 module Arel

--- a/lib/arel/visitors/visitor.rb
+++ b/lib/arel/visitors/visitor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module Visitors
     class Visitor

--- a/lib/arel/window_predications.rb
+++ b/lib/arel/window_predications.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arel
   module WindowPredications
 

--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'ostruct'
 

--- a/test/collectors/test_bind_collector.rb
+++ b/test/collectors/test_bind_collector.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'arel/collectors/bind'
 

--- a/test/collectors/test_sql_string.rb
+++ b/test/collectors/test_sql_string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'arel/collectors/bind'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubygems'
 require 'minitest/autorun'
 require 'fileutils'

--- a/test/nodes/test_and.rb
+++ b/test/nodes/test_and.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_as.rb
+++ b/test/nodes/test_as.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_ascending.rb
+++ b/test/nodes/test_ascending.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_bin.rb
+++ b/test/nodes/test_bin.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_binary.rb
+++ b/test/nodes/test_binary.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'set'
 

--- a/test/nodes/test_bind_param.rb
+++ b/test/nodes/test_bind_param.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_case.rb
+++ b/test/nodes/test_case.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_casted.rb
+++ b/test/nodes/test_casted.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_count.rb
+++ b/test/nodes/test_count.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::Count do

--- a/test/nodes/test_delete_statement.rb
+++ b/test/nodes/test_delete_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::DeleteStatement do

--- a/test/nodes/test_descending.rb
+++ b/test/nodes/test_descending.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_distinct.rb
+++ b/test/nodes/test_distinct.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_equality.rb
+++ b/test/nodes/test_equality.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_extract.rb
+++ b/test/nodes/test_extract.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::Extract do

--- a/test/nodes/test_false.rb
+++ b/test/nodes/test_false.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_grouping.rb
+++ b/test/nodes/test_grouping.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_infix_operation.rb
+++ b/test/nodes/test_infix_operation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_insert_statement.rb
+++ b/test/nodes/test_insert_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::InsertStatement do

--- a/test/nodes/test_named_function.rb
+++ b/test/nodes/test_named_function.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_node.rb
+++ b/test/nodes/test_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_not.rb
+++ b/test/nodes/test_not.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_or.rb
+++ b/test/nodes/test_or.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_over.rb
+++ b/test/nodes/test_over.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::Over do

--- a/test/nodes/test_select_core.rb
+++ b/test/nodes/test_select_core.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_select_statement.rb
+++ b/test/nodes/test_select_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::SelectStatement do

--- a/test/nodes/test_sql_literal.rb
+++ b/test/nodes/test_sql_literal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'yaml'
 

--- a/test/nodes/test_sum.rb
+++ b/test/nodes/test_sum.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::Sum do

--- a/test/nodes/test_table_alias.rb
+++ b/test/nodes/test_table_alias.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'ostruct'
 

--- a/test/nodes/test_true.rb
+++ b/test/nodes/test_true.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_unary_operation.rb
+++ b/test/nodes/test_unary_operation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/nodes/test_update_statement.rb
+++ b/test/nodes/test_update_statement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 describe Arel::Nodes::UpdateStatement do

--- a/test/nodes/test_window.rb
+++ b/test/nodes/test_window.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module FakeRecord
   class Column < Struct.new(:name, :type)
   end

--- a/test/test_attributes.rb
+++ b/test/test_attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/test_crud.rb
+++ b/test/test_crud.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/test_delete_manager.rb
+++ b/test/test_delete_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/test_factory_methods.rb
+++ b/test/test_factory_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/test_insert_manager.rb
+++ b/test/test_insert_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/test_update_manager.rb
+++ b/test/test_update_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_bind_visitor.rb
+++ b/test/visitors/test_bind_visitor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'arel/visitors/bind_visitor'
 require 'support/fake_record'

--- a/test/visitors/test_depth_first.rb
+++ b/test/visitors/test_depth_first.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'set'
 

--- a/test/visitors/test_dispatch_contamination.rb
+++ b/test/visitors/test_dispatch_contamination.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_dot.rb
+++ b/test/visitors/test_dot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_ibm_db.rb
+++ b/test/visitors/test_ibm_db.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_informix.rb
+++ b/test/visitors/test_informix.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_mssql.rb
+++ b/test/visitors/test_mssql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_mysql.rb
+++ b/test/visitors/test_mysql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_oracle12.rb
+++ b/test/visitors/test_oracle12.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_sqlite.rb
+++ b/test/visitors/test_sqlite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 
 module Arel

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'helper'
 require 'set'
 


### PR DESCRIPTION
To avoid having to explicitly call freeze or store strings in constants we are now enabling the frozen_string_literal magic comment.