### PR TITLE
Make Visitor visit thread safe by holding dispatch method reference

### DIFF
--- a/arel.gemspec
+++ b/arel.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', '~> 5.4')
   s.add_development_dependency('rdoc', '~> 4.0')
   s.add_development_dependency('rake')
+  s.add_development_dependency('concurrent-ruby', '~> 1.0')
 end

--- a/arel.gemspec.erb
+++ b/arel.gemspec.erb
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', '~> 5.4')
   s.add_development_dependency('rdoc', '~> 4.0')
   s.add_development_dependency('rake')
+  s.add_development_dependency('concurrent-ruby', '~> 1.0')
 end

--- a/lib/arel/visitors/reduce.rb
+++ b/lib/arel/visitors/reduce.rb
@@ -11,9 +11,10 @@ module Arel
       private
 
       def visit object, collector
-        send dispatch[object.class], object, collector
+        dispatch_method = dispatch[object.class]
+        send dispatch_method, object, collector
       rescue NoMethodError => e
-        raise e if respond_to?(dispatch[object.class], true)
+        raise e if respond_to?(dispatch_method, true)
         superklass = object.class.ancestors.find { |klass|
           respond_to?(dispatch[klass], true)
         }

--- a/lib/arel/visitors/visitor.rb
+++ b/lib/arel/visitors/visitor.rb
@@ -27,9 +27,10 @@ module Arel
       end
 
       def visit object
-        send dispatch[object.class], object
+        dispatch_method = dispatch[object.class]
+        send dispatch_method, object
       rescue NoMethodError => e
-        raise e if respond_to?(dispatch[object.class], true)
+        raise e if respond_to?(dispatch_method, true)
         superklass = object.class.ancestors.find { |klass|
           respond_to?(dispatch[klass], true)
         }

--- a/test/visitors/test_dispatch_contamination.rb
+++ b/test/visitors/test_dispatch_contamination.rb
@@ -1,8 +1,42 @@
 # frozen_string_literal: true
 require 'helper'
+require 'concurrent'
 
 module Arel
   module Visitors
+    class DummyVisitor < Visitor
+      def initialize
+        super
+        @barrier = Concurrent::CyclicBarrier.new(2)
+      end
+
+      def visit_Arel_Visitors_DummySuperNode node
+        42
+      end
+
+      # This is terrible, but it's the only way to reliably reproduce
+      # the possible race where two threads attempt to correct the
+      # dispatch hash at the same time.
+      def send *args
+        super
+      rescue
+        # Both threads try (and fail) to dispatch to the subclass's name
+        @barrier.wait
+        raise
+      ensure
+        # Then one thread successfully completes (updating the dispatch
+        # table in the process) before the other finishes raising its
+        # exception.
+        Thread.current[:delay].wait if Thread.current[:delay]
+      end
+    end
+
+    class DummySuperNode
+    end
+
+    class DummySubNode < DummySuperNode
+    end
+
     describe 'avoiding contamination between visitor dispatch tables' do
       before do
         @connection = Table.engine.connection
@@ -16,6 +50,21 @@ module Arel
         node.first # from Nodes::Node's Enumerable mixin
 
         assert_equal "( TRUE UNION FALSE )", node.to_sql
+      end
+
+      it 'is threadsafe when implementing superclass fallback' do
+        visitor = DummyVisitor.new
+        main_thread_finished = Concurrent::Event.new
+
+        racing_thread = Thread.new do
+          Thread.current[:delay] = main_thread_finished
+          visitor.accept DummySubNode.new
+        end
+
+        assert_equal 42, visitor.accept(DummySubNode.new)
+        main_thread_finished.set
+
+        assert_equal 42, racing_thread.value
       end
     end
   end


### PR DESCRIPTION
This is an alternative to https://github.com/rails/arel/pull/465

We experienced this under jruby in production, and it looks like we're not alone:

rails/rails#26571
jruby/activerecord-jdbc-adapter#739

This change doesn't change behavior, but it does fix the following problem:

1. [thread 1] dispatches with `dispatch[object.class]` and a `NoMethodError` is raised.
2. [thread 1] now checks `respond_to?(dispatch[object.class])` and returns `false`.
3. [thread 1] begins walking the ancestor tree.
4. [thread 2] dispatches with `dispatch[object.class]` and a `NoMethodError` is raised.
5. [thread 1] finds a super class and swaps it out in the dispatch cache: `dispatch[object.class] = superklass`.
6. [thread 2] now checks `respond_to?(dispatch[object.class])` and returns `true`, because the dispatch cache has changed, and an error is raised 😱 .

This PR makes each visit method store the `dispatch[object.class]` into a `dispatch_method` variable to prevent either thread from being impacted by the `dispatch` cached change.

So what happens when two threads hit the visit method now? With this change, both threads will walk through the ancestors, find a matching super class, and write it to the dispatch class. When either retries, they'll get the correct info. In other words, they'll both end up updating the `dispatch` cache with the same value. This is much better than an error being raised for one of them.

TESTING:

I was able to reproduce this by adding some random sleeps into the visitor to path like @abrandoned did. Wherever you see `HERE`, it means a `NoMethodError` was raised and we're about to check `respond_to?`. The test starts 20 threads and each thread runs the [dispatch contamination test](https://github.com/rails/arel/blob/208fe3690d840d0ee65b1395a891886e58fd3f4b/test/visitors/test_dispatch_contamination.rb#L12-L19) 10 times.

Before: 
```
...
thread opened
thread opened
thread opened
thread opened
thread opened
thread opened
HEREHERE

E.

Finished in 1.234906s, 1.6196 runs/s, 24.2933 assertions/s.

  1) Error:
avoiding contamination between visitor dispatch tables#test_0002_does not throw NoMethodError when multi-threaded defining "visit":
NoMethodError: undefined method `visit_Arel_Nodes_Union' for #<Arel::Visitors::DepthFirst:0x6a8658ff>
Did you mean?  visit_Arel_Nodes_Grouping
               visit_Arel_Nodes_OuterJoin
               visit_Arel_Nodes_Sum
...
```

After:
```
...
thread opened
thread opened
thread opened
thread opened
thread opened
HERE
HERE
HERE
HEREHERE

HERE
thread done
thread done
thread done
thread done
thread done
thread done
...
```

EDIT: Forgot to link to the test gist: https://gist.github.com/film42/6e43ce2f27d2f91ee4daf011a20e1c0d