### PR TITLE
Remove unused `engine`

### DIFF
--- a/lib/arel/tree_manager.rb
+++ b/lib/arel/tree_manager.rb
@@ -5,7 +5,7 @@ module Arel
   class TreeManager
     include Arel::FactoryMethods
 
-    attr_reader :ast, :engine
+    attr_reader :ast
 
     attr_accessor :bind_values
 

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -226,7 +226,7 @@ module Arel
         table = Table.new(:users)
         manager = Arel::SelectManager.new table
         manager.project Nodes::SqlLiteral.new '*'
-        m2 = Arel::SelectManager.new(manager.engine)
+        m2 = Arel::SelectManager.new
         m2.project manager.exists
         m2.to_sql.must_be_like %{ SELECT EXISTS (#{manager.to_sql}) }
       end
@@ -235,7 +235,7 @@ module Arel
         table = Table.new(:users)
         manager = Arel::SelectManager.new table
         manager.project Nodes::SqlLiteral.new '*'
-        m2 = Arel::SelectManager.new(manager.engine)
+        m2 = Arel::SelectManager.new
         m2.project manager.exists.as('foo')
         m2.to_sql.must_be_like %{ SELECT EXISTS (#{manager.to_sql}) AS foo }
       end


### PR DESCRIPTION
Follow up of 98fc25991137ee09b6800578117f8c1c322680f2.

`engine` is only used for `to_sql` and `where_sql` now.