### PR TITLE
Support INSERT with multiple values (v2)

### DIFF
--- a/lib/arel/insert_manager.rb
+++ b/lib/arel/insert_manager.rb
@@ -40,5 +40,9 @@ module Arel
     def create_values values, columns
       Nodes::Values.new values, columns
     end
+
+    def create_values_list(rows)
+      Nodes::ValuesList.new(rows)
+    end
   end
 end

--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -44,6 +44,7 @@ require 'arel/nodes/function'
 require 'arel/nodes/count'
 require 'arel/nodes/extract'
 require 'arel/nodes/values'
+require 'arel/nodes/values_list'
 require 'arel/nodes/named_function'
 
 # windows

--- a/lib/arel/nodes/values_list.rb
+++ b/lib/arel/nodes/values_list.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Arel
+  module Nodes
+    class ValuesList < Node
+      attr_reader :rows
+
+      def initialize(rows)
+        @rows = rows
+        super()
+      end
+    end
+  end
+end

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -166,6 +166,28 @@ module Arel
         collector << "FALSE"
       end
 
+      def visit_Arel_Nodes_ValuesList o, collector
+        collector << "VALUES "
+
+        len = o.rows.length - 1
+        o.rows.each_with_index { |row, i|
+          collector << '('
+          row_len = row.length - 1
+          row.each_with_index do |value, k|
+            case value
+            when Nodes::SqlLiteral, Nodes::BindParam
+              collector = visit(value, collector)
+            else
+              collector << quote(value)
+            end
+            collector << COMMA unless k == row_len
+          end
+          collector << ')'
+          collector << COMMA unless i == len
+        }
+        collector
+      end
+
       def visit_Arel_Nodes_Values o, collector
         collector << "VALUES ("
 

--- a/test/test_insert_manager.rb
+++ b/test/test_insert_manager.rb
@@ -28,6 +28,60 @@ module Arel
         }
       end
 
+      it 'works with multiple values' do
+        table = Table.new(:users)
+        manager = Arel::InsertManager.new
+        manager.into table
+
+        manager.columns << table[:id]
+        manager.columns << table[:name]
+
+        manager.values = manager.create_values_list([
+          %w{1 david},
+          %w{2 kir},
+          ["3", Arel.sql('DEFAULT')],
+        ])
+
+        manager.to_sql.must_be_like %{
+          INSERT INTO \"users\" (\"id\", \"name\") VALUES ('1', 'david'), ('2', 'kir'), ('3', DEFAULT)
+        }
+      end
+
+      it 'literals in multiple values are not escaped' do
+        table = Table.new(:users)
+        manager = Arel::InsertManager.new
+        manager.into table
+
+        manager.columns << table[:name]
+
+        manager.values = manager.create_values_list([
+          [Arel.sql('*')],
+          [Arel.sql('DEFAULT')],
+        ])
+
+        manager.to_sql.must_be_like %{
+          INSERT INTO \"users\" (\"name\") VALUES (*), (DEFAULT)
+        }
+      end
+
+      it 'works with multiple single values' do
+        table = Table.new(:users)
+        manager = Arel::InsertManager.new
+        manager.into table
+
+        manager.columns << table[:name]
+
+        manager.values = manager.create_values_list([
+          %w{david},
+          %w{kir},
+          [Arel.sql('DEFAULT')],
+        ])
+
+        manager.to_sql.must_be_like %{
+          INSERT INTO \"users\" (\"name\") VALUES ('david'), ('kir'), (DEFAULT)
+        }
+      end
+
       it "inserts false" do
         table = Table.new(:users)
         manager = Arel::InsertManager.new


### PR DESCRIPTION
This is another attempt to implement support for INSERT queries with multiple values:

```sql
INSERT INTO people (name) VALUES ('dhh', 'rafael', 'kir')
```

This feature would allow me to speed up ActiveRecord fixtures  (https://github.com/rails/rails/pull/26901).

The first implementation (https://github.com/rails/arel/pull/482) had to be reverted because it broke things. In this PR, I tried to design it in a way that the new feature wouldn't break any existing behaviour.

review @kamipo @rafaelfranca @matthewd 