### PR TITLE
Remove unused `bind_values`

### DIFF
--- a/lib/arel/tree_manager.rb
+++ b/lib/arel/tree_manager.rb
@@ -7,11 +7,8 @@ module Arel
 
     attr_reader :ast
 
-    attr_accessor :bind_values
-
     def initialize
-      @ctx    = nil
-      @bind_values = []
+      @ctx = nil
     end
 
     def to_dot

--- a/test/test_select_manager.rb
+++ b/test/test_select_manager.rb
@@ -10,13 +10,6 @@ module Arel
       assert_equal "SELECT FROM 'foo'", manager.to_sql
     end
 
-    def test_manager_stores_bind_values
-      manager = Arel::SelectManager.new
-      assert_equal [], manager.bind_values
-      manager.bind_values = [1]
-      assert_equal [1], manager.bind_values
-    end
-
     describe 'backwards compatibility' do
       describe 'project' do
         it 'accepts symbols as sql literals' do


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/213796f, `bind_values` is no longer used from Active Record.