### PR TITLE
Add missing hash, eql?, == to various node classes

### DIFF
--- a/lib/arel/nodes/bind_param.rb
+++ b/lib/arel/nodes/bind_param.rb
@@ -9,10 +9,15 @@ module Arel
         super()
       end
 
-      def ==(other)
+      def hash
+        [self.class, self.value].hash
+      end
+
+      def eql?(other)
         other.is_a?(BindParam) &&
           value == other.value
       end
+      alias :== :eql?
 
       def nil?
         value.nil?

--- a/lib/arel/nodes/false.rb
+++ b/lib/arel/nodes/false.rb
@@ -9,6 +9,7 @@ module Arel
       def eql? other
         self.class == other.class
       end
+      alias :== :eql?
     end
   end
 end

--- a/lib/arel/nodes/function.rb
+++ b/lib/arel/nodes/function.rb
@@ -29,6 +29,8 @@ module Arel
           self.alias == other.alias &&
           self.distinct == other.distinct
       end
+      alias :== :eql?
+
     end
 
     %w{

--- a/lib/arel/nodes/terminal.rb
+++ b/lib/arel/nodes/terminal.rb
@@ -9,6 +9,7 @@ module Arel
       def eql? other
         self.class == other.class
       end
+      alias :== :eql?
     end
   end
 end

--- a/lib/arel/nodes/true.rb
+++ b/lib/arel/nodes/true.rb
@@ -9,6 +9,7 @@ module Arel
       def eql? other
         self.class == other.class
       end
+      alias :== :eql?
     end
   end
 end

--- a/lib/arel/nodes/values_list.rb
+++ b/lib/arel/nodes/values_list.rb
@@ -8,6 +8,16 @@ module Arel
         @rows = rows
         super()
       end
+
+      def hash
+        @rows.hash
+      end
+
+      def eql? other
+        self.class == other.class &&
+          self.rows == other.rows
+      end
+      alias :== :eql?
     end
   end
 end

--- a/lib/arel/nodes/window.rb
+++ b/lib/arel/nodes/window.rb
@@ -107,6 +107,7 @@ module Arel
       def eql? other
         self.class == other.class
       end
+      alias :== :eql?
     end
 
     class Preceding < Unary

--- a/test/test_nodes.rb
+++ b/test/test_nodes.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'helper'
+
+module Arel
+  module Nodes
+    class TestNodes < Minitest::Test
+      def test_every_arel_nodes_have_hash_eql_eqeq_from_same_class
+        # #descendants code from activesupport
+        node_descendants = []
+        ObjectSpace.each_object(Arel::Nodes::Node.singleton_class) do |k|
+          next if k.respond_to?(:singleton_class?) && k.singleton_class?
+          node_descendants.unshift k unless k == self
+        end
+        node_descendants.delete(Arel::Nodes::Node)
+
+        bad_node_descendants = node_descendants.reject do |subnode|
+          eqeq_owner = subnode.instance_method(:==).owner
+          eql_owner = subnode.instance_method(:eql?).owner
+          hash_owner = subnode.instance_method(:hash).owner
+
+          eqeq_owner < Arel::Nodes::Node &&
+              eqeq_owner == eql_owner &&
+              eqeq_owner == hash_owner
+        end
+
+        problem_msg = 'Some subclasses of Arel::Nodes::Node do not have a' \
+            ' #== or #eql? or #hash defined from the same class as the others'
+        assert_empty bad_node_descendants, problem_msg
+      end
+
+
+    end
+  end
+end


### PR DESCRIPTION
Some of the nodes classes are missing either one or many of the common comparison methods #hash, #eql? and #==. 

This makes comparision and working with the ast sometimes painful, as equality or operations likes array differences (which uses a hash behind the scene) produces unexpected results.

A test has been added that ensures that every descendants of Node:
* have all 3 methods
* that all 3 methods were defined from the same class 
* that the class defining all 3 is also a descendant of Node, to avoid the default ones that rely on identity only