### PR TITLE
Remove Unused variable - offset_bind

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -29,7 +29,6 @@ module Arel
           collector = super(o, collector)
 
           if offset.expr.is_a? Nodes::BindParam
-            offset_bind = nil
             collector << ') raw_sql_ WHERE rownum <= ('
             collector = visit offset.expr, collector
             collector << ' + '


### PR DESCRIPTION
Fixes warning in Rails tests:

```
/home/travis/build/rails/rails/vendor/bundle/ruby/2.4.0/bundler/gems/arel-b9ca36f09d5e/lib/arel/visitors/oracle.rb:32: warning: assigned but unused variable - offset_bind
``