### PR TITLE
Remove encoding utf-8 magic comment

### DIFF
--- a/arel.gemspec
+++ b/arel.gemspec
@@ -1,4 +1,3 @@
-# # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
 require "arel"

--- a/arel.gemspec.erb
+++ b/arel.gemspec.erb
@@ -1,4 +1,3 @@
-# # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
 require "arel"

--- a/lib/arel/collectors/sql_string.rb
+++ b/lib/arel/collectors/sql_string.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'arel/collectors/plain_string'


### PR DESCRIPTION
### Summary

The default script encoding from Ruby 2.0 is UTF-8.

https://bugs.ruby-lang.org/issues/6679

There are unnecessary `# encoding: utf-8` magic comment. AFAIK, Arel is currently tested Ruby 2.0.0 or higher on Travis CI. This PR removes magic comment.

### Other Information

The following commit has been removed Ruby 1.9 support.

https://github.com/rails/arel/commit/f1a3421ce7083181ebd463c8147c2d4b95539ca8