### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,18 @@ env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
 rvm:
-  - rbx-2
-  - jruby-9.0.5.0
-  - jruby-head
-  - 2.0.0
-  - 2.1
-  - 2.2.5
-  - 2.3.1
+  - 2.2.7
+  - 2.3.4
   - 2.4.1
   - ruby-head
+  - jruby-9.1.12.0
+  - jruby-head
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: jruby-9.0.5.0
-    - rvm: jruby-head
     - rvm: ruby-head
+    - rvm: jruby-9.1.12.0
     - rvm: jruby-head
-    - rvm: rbx-2
 bundler_args: --jobs 3 --retry 3
 notifications:
   email: false

--- a/arel.gemspec
+++ b/arel.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Arel Really Exasperates Logicians\n\nArel is a SQL AST manager for Ruby. It\n\n1. Simplifies the generation of complex SQL queries\n2. Adapts to various RDBMSes\n\nIt is intended to be a framework framework; that is, you can build your own ORM\nwith it, focusing on innovative object and collection modeling as opposed to\ndatabase compatibility and query generation."
   s.summary     = "Arel Really Exasperates Logicians  Arel is a SQL AST manager for Ruby"
   s.license     = %q{MIT}
+  s.required_ruby_version = ">= 2.2.2"
 
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files = ["History.txt", "MIT-LICENSE.txt", "README.md"]

--- a/arel.gemspec.erb
+++ b/arel.gemspec.erb
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Arel Really Exasperates Logicians\n\nArel is a SQL AST manager for Ruby. It\n\n1. Simplifies the generation of complex SQL queries\n2. Adapts to various RDBMSes\n\nIt is intended to be a framework framework; that is, you can build your own ORM\nwith it, focusing on innovative object and collection modeling as opposed to\ndatabase compatibility and query generation."
   s.summary     = "Arel Really Exasperates Logicians  Arel is a SQL AST manager for Ruby"
   s.license     = %q{MIT}
+  s.required_ruby_version = ">= 2.2.2"
 
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files = ["History.txt", "MIT-LICENSE.txt", "README.md"]


### PR DESCRIPTION
Follow up of https://github.com/rails/arel/pull/494#issuecomment-321524575.

Arel tested Ruby 2.0.0 or higher with Travis CI, so I wrote that version to `required_ruby_version`.