### PR TITLE
Fix YAML dump/load issues with SqlLiteral node.

### DIFF
--- a/lib/arel/nodes/sql_literal.rb
+++ b/lib/arel/nodes/sql_literal.rb
@@ -1,14 +1,25 @@
 # frozen_string_literal: true
+
+require 'forwardable'
+
 module Arel
   module Nodes
-    class SqlLiteral < String
+    class SqlLiteral
       include Arel::Expressions
       include Arel::Predications
       include Arel::AliasPredication
       include Arel::OrderPredications
+      extend Forwardable
 
-      def encode_with(coder)
-        coder.scalar = self.to_s
+      def_delegators :@string,
+                     :===, :==, :to_str, :to_s, :gsub, :inspect, :hash
+
+      def eql?(val)
+        self == val
+      end
+
+      def initialize(string)
+        @string = string
       end
     end
   end

--- a/lib/arel/update_manager.rb
+++ b/lib/arel/update_manager.rb
@@ -42,7 +42,8 @@ module Arel
     end
 
     def set values
-      if String === values
+      case values
+      when String, Nodes::SqlLiteral
         @ast.values = [values]
       else
         @ast.values = values.map { |column,value|

--- a/test/nodes/test_sql_literal.rb
+++ b/test/nodes/test_sql_literal.rb
@@ -65,8 +65,11 @@ module Arel
 
       describe 'serialization' do
         it 'serializes into YAML' do
-          yaml_literal = SqlLiteral.new('foo').to_yaml
-          assert_equal('foo', YAML.load(yaml_literal))
+          literal = SqlLiteral.new('foo')
+          yaml_literal = literal.to_yaml
+          revived = YAML.load(yaml_literal)
+          assert_equal(literal, revived)
+          revived.must_be_kind_of Arel::Nodes::SqlLiteral
         end
       end
     end


### PR DESCRIPTION
Resolves issue demonstrated below:

``` ruby
require 'psych'
require 'arel'
yaml = Arel::Nodes::SqlLiteral.new('*').to_yaml
puts Psych.load(yaml).is_a?(Arel::Nodes::SqlLiteral) # false
```

When deserializing an Arel query containing a SqlLiteral node, Arel breaks as
it expects a Node, but instead gets a String, preventing the query from being
loaded.

Note that I only delegated `String` methods that are covered by tests - interested in feedback on how much of the `String` contract should be implemented for cases where users are expecting the object to quack like a `String` (and open to suggestions for how to address this).