### PR TITLE
Fix: Don't emit multiple parens for multiple union alls

### DIFF
--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -3,34 +3,6 @@ module Arel
   module Visitors
     class MySQL < Arel::Visitors::ToSql
       private
-      def visit_Arel_Nodes_Union o, collector, suppress_parens = false
-        unless suppress_parens
-          collector << "( "
-        end
-
-        collector =   case o.left
-                      when Arel::Nodes::Union
-                        visit_Arel_Nodes_Union o.left, collector, true
-                      else
-                        visit o.left, collector
-                      end
-
-        collector << " UNION "
-
-        collector =    case o.right
-                       when Arel::Nodes::Union
-                         visit_Arel_Nodes_Union o.right, collector, true
-                       else
-                         visit o.right, collector
-                       end
-
-        if suppress_parens
-          collector
-        else
-          collector << " )"
-        end
-      end
-
       def visit_Arel_Nodes_Bin o, collector
         collector << "BINARY "
         visit o.expr, collector

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -296,13 +296,11 @@ module Arel
       end
 
       def visit_Arel_Nodes_Union o, collector
-        collector << "( "
-        infix_value(o, collector, " UNION ") << " )"
+        infix_value_with_paren(o, collector, " UNION ")
       end
 
       def visit_Arel_Nodes_UnionAll o, collector
-        collector << "( "
-        infix_value(o, collector, " UNION ALL ") << " )"
+        infix_value_with_paren(o, collector, " UNION ALL ")
       end
 
       def visit_Arel_Nodes_Intersect o, collector
@@ -830,6 +828,25 @@ module Arel
         collector = visit o.left, collector
         collector << value
         visit o.right, collector
+      end
+
+      def infix_value_with_paren o, collector, value, suppress_parens = false
+        collector << '( ' unless suppress_parens
+
+        collector = if o.left.class == o.class
+                      infix_value_with_paren(o.left, collector, value, true)
+                    else
+                      visit o.left, collector
+                    end
+        collector << value
+        collector = if o.right.class == o.class
+                      infix_value_with_paren(o.right, collector, value, true)
+                    else
+                      visit o.right, collector
+                    end
+
+        collector << ' )' unless suppress_parens
+        collector
       end
 
       def aggregate name, o, collector

--- a/test/visitors/test_mysql.rb
+++ b/test/visitors/test_mysql.rb
@@ -12,16 +12,6 @@ module Arel
         @visitor.accept(node, Collectors::SQLString.new).value
       end
 
-      it 'squashes parenthesis on multiple unions' do
-        subnode = Nodes::Union.new Arel.sql('left'), Arel.sql('right')
-        node    = Nodes::Union.new subnode, Arel.sql('topright')
-        assert_equal 1, compile(node).scan('(').length
-
-        subnode = Nodes::Union.new Arel.sql('left'), Arel.sql('right')
-        node    = Nodes::Union.new Arel.sql('topleft'), subnode
-        assert_equal 1, compile(node).scan('(').length
-      end
-
       ###
       # :'(
       # http://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -479,6 +479,30 @@ module Arel
         end
       end
 
+      describe "Nodes::Union" do
+        it 'squashes parenthesis on multiple unions' do
+          subnode = Nodes::Union.new Arel.sql('left'), Arel.sql('right')
+          node    = Nodes::Union.new subnode, Arel.sql('topright')
+          assert_equal("( left UNION right UNION topright )", compile(node))
+
+          subnode = Nodes::Union.new Arel.sql('left'), Arel.sql('right')
+          node    = Nodes::Union.new Arel.sql('topleft'), subnode
+          assert_equal("( topleft UNION left UNION right )", compile(node))
+        end
+      end
+
+      describe "Nodes::UnionAll" do
+        it 'squashes parenthesis on multiple union alls' do
+          subnode = Nodes::UnionAll.new Arel.sql('left'), Arel.sql('right')
+          node    = Nodes::UnionAll.new subnode, Arel.sql('topright')
+          assert_equal("( left UNION ALL right UNION ALL topright )", compile(node))
+
+          subnode = Nodes::UnionAll.new Arel.sql('left'), Arel.sql('right')
+          node    = Nodes::UnionAll.new Arel.sql('topleft'), subnode
+          assert_equal("( topleft UNION ALL left UNION ALL right )", compile(node))
+        end
+      end
+
       describe "Nodes::NotIn" do
         it "should know how to visit" do
           node = @attr.not_in [1, 2, 3]


### PR DESCRIPTION
This emits SQL without adding extra parens to multiple `UNION ALL` statements in a row.

Fixes #58 
Fixes #158 
Fixes #299
Fixes #341
Fixes #404
Fixes #418 

### Before:

The MySQL adapter overrides the `Union` visitor but not the `UnionAll` one.
What will come as no surprise, Arel generates the correct `UNION` statement for Mysql.
Unfortunately, `UNION ALL` on MySql and `UNION` for the other databases are incorrect.

### After:

Arel generates the correct `UNION ALL` and `UNION` statements for all databases. (Correct meaning without extra parentheses.)

In order to know that parens have already been generated, it calls the visitor method directly if the child class is the same. (This will be the `Union` or `UnionAll` nodes). It passes in a parameter to omit the unwanted parenthesis.

I like not changing the method signature of the `visit_*` method but do not like skipping the call into the `visitor` infrastructure. But since this node is the same class, it is known to support this method.

**UPDATE:** The spacing around the parenthesis could be removed, and produces prettier SQL. Let me know if you want me to do this here or submit a followup. It changes a dozen other tests.

### NOTE:

- WARNING: I played with the tests, but not run in the DB itself.
- @bughit could you test this PR to see if it fixes your issue? Thnx
- @matthewd Hi :)
