### PR TITLE
Explicitly mentions the #and operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,13 @@ The `OR` operator works like this:
 users.where(users[:name].eq('bob').or(users[:age].lt(25)))
 ```
 
-The `AND` operator behaves similarly. Here is an example of the `DISTINCT` operator:
+The `AND` operator behaves similarly (same exact behaviour as chained calls to `.where`):
+
+```ruby
+users.where(users[:name].eq('bob').and(users[:age].lt(25)))
+```
+
+Here is an example of the `DISTINCT` operator:
 
 ```ruby
 posts = Arel::Table.new(:posts)


### PR DESCRIPTION
This PR adds explicit documentation for the `.and` operator in AREL. It is true that it was already included existing documentation ("behaves similarly" to `.or`), but wasn't explicit enough when I was searching the README (via CMD-F) for an example of a call to `.and`.

I ended up learning about the existence of `.and` through [this blog post](https://www.viget.com/articles/composable-sql-queries-in-rails-using-arel). I would have preferred to intake this code example through the official README instead. Hopefully this PR will allow future developers using AREL to do so.

By the way, I also moved documentation about `DISTINCT` to its own paragraph. It seems more appropriate to be separate from `OR` and `AND` documentation.