### PR TITLE
Fix: Return required `require`

### DIFF
--- a/lib/arel/tree_manager.rb
+++ b/lib/arel/tree_manager.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'arel/collectors/sql_string'
+
 module Arel
   class TreeManager
     include Arel::FactoryMethods

--- a/test/collectors/test_bind.rb
+++ b/test/collectors/test_bind.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'helper'
+require 'arel/collectors/bind'
 
 module Arel
   module Collectors

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'date'
+
 module FakeRecord
   class Column < Struct.new(:name, :type)
   end


### PR DESCRIPTION
Some of them uses for single test run, like:
```sh
bundle exec ruby -I./lib:./test -S minitest  test/test_update_manager.rb
```