### PR TITLE
Add #to_sql method for attributes

### DIFF
--- a/lib/arel/attributes/attribute.rb
+++ b/lib/arel/attributes/attribute.rb
@@ -21,6 +21,15 @@ module Arel
       def able_to_type_cast?
         relation.able_to_type_cast?
       end
+
+      # Returns full qualified table and column name for this attribute
+      # @see Arel::Visitors::ToSql#visit_Arel_Attributes_Attribute
+      def to_sql
+        relation.class.engine.connection.visitor.accept(
+          self, Arel::Collectors::SQLString.new
+        ).value
+      end
+      alias :to_s :to_sql
     end
 
     class String    < Attribute; end

--- a/lib/arel/nodes/node.rb
+++ b/lib/arel/nodes/node.rb
@@ -47,6 +47,7 @@ module Arel
         collector = engine.connection.visitor.accept self, collector
         collector.value
       end
+      alias :to_s :to_sql
 
       # Iterate through AST, nodes will be yielded depth-first
       def each &block

--- a/test/attributes/test_attribute.rb
+++ b/test/attributes/test_attribute.rb
@@ -961,6 +961,23 @@ module Arel
           }
         end
       end
+
+      describe '#to_sql' do
+        it 'should return full qualified column name' do
+          relation = Table.new(:users)
+          relation[:id].to_sql.must_be_like '"users"."id"'
+        end
+      end
+
+      describe '#to_s' do
+        it 'should return full qualified column name' do
+          rel = Table.new(:users)
+          "SUM(#{rel[:sign_in_count]}) FILTER (WHERE #{rel[:bar].eq(nil)})" \
+            .must_be_like %{
+              SUM("users"."sign_in_count") FILTER (WHERE "users"."bar" IS NULL)
+            }
+        end
+      end
     end
 
     describe 'equality' do


### PR DESCRIPTION
It allows to more easily and safely construct complicated SQL expressions by using string interpolation for SQL features not supported in Arel yet.

Consider this ActiveRecord example:

```ruby
facts = Feature::Fact.arel_table
recs  = Feature::Recommendation.arel_table
Feature::Recommendation.left_outer_joins(:fact).pluck_to_struct(
  "COUNT(*) AS recommendations_total",
  "SUM(#{facts[:value]}) FILTER (WHERE #{recs[:some_flag].not_eq(nil)}) AS recommendations_applied",
).first
```

Which will produce something like:

```sql
SELECT
  COUNT(*) AS recommendations_total,
  SUM("feature_facts"."value") FILTER (WHERE "feature_recommendations"."some_flag" IS NOT NULL) AS recommendations_applied
FROM "feature_recommendations"
  LEFT OUTER JOIN "feature_facts" ON …
```
I believe it will be most useful in case of namespaced long table names.