### PR TITLE
CI with Ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
     - rvm: jruby-9.1.12.0
     - rvm: jruby-head
 bundler_args: --jobs 3 --retry 3
+before_install:
+  - "travis_retry gem update --system"
 notifications:
   email: false
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.2.8
   - 2.3.5
   - 2.4.2
+  - 2.5.0
   - ruby-head
   - jruby-9.1.12.0
   - jruby-head

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+
+require 'date'
 module FakeRecord
   class Column < Struct.new(:name, :type)
   end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -233,7 +233,7 @@ module Arel
       end
 
       it "should visit_BigDecimal" do
-        compile Nodes.build_quoted(BigDecimal.new('2.14'))
+        compile Nodes.build_quoted(BigDecimal('2.14'))
       end
 
       it "should visit_Date" do


### PR DESCRIPTION
This pull request adds CI with Ruby 2.5.0. It would fail with Ruby 2.5.0 and ruby-head due to `NameError: uninitialized constant FakeRecord::Connection::DateTime` I'll open another issue for this error.

Updated: `NameError: uninitialized constant FakeRecord::Connection::DateTime` has been addressed in this pull request.
  