### PR TITLE
Add support for FILTER clause (SQL:2003)

### DIFF
--- a/lib/arel.rb
+++ b/lib/arel.rb
@@ -6,6 +6,7 @@ require 'arel/factory_methods'
 
 require 'arel/expressions'
 require 'arel/predications'
+require 'arel/filter_predications'
 require 'arel/window_predications'
 require 'arel/math'
 require 'arel/alias_predication'

--- a/lib/arel/filter_predications.rb
+++ b/lib/arel/filter_predications.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Arel
+  module FilterPredications
+
+    def filter(expr)
+      Nodes::Filter.new(self, expr)
+    end
+
+  end
+end

--- a/lib/arel/nodes.rb
+++ b/lib/arel/nodes.rb
@@ -32,6 +32,7 @@ require 'arel/nodes/table_alias'
 require 'arel/nodes/infix_operation'
 require 'arel/nodes/unary_operation'
 require 'arel/nodes/over'
+require 'arel/nodes/filter'
 require 'arel/nodes/matches'
 require 'arel/nodes/regexp'
 

--- a/lib/arel/nodes/filter.rb
+++ b/lib/arel/nodes/filter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Arel
+  module Nodes
+
+    class Filter < Binary
+      include Arel::WindowPredications
+      include Arel::AliasPredication
+    end
+
+  end
+end

--- a/lib/arel/nodes/function.rb
+++ b/lib/arel/nodes/function.rb
@@ -3,6 +3,7 @@ module Arel
   module Nodes
     class Function < Arel::Nodes::NodeExpression
       include Arel::WindowPredications
+      include Arel::FilterPredications
       attr_accessor :expressions, :alias, :distinct
 
       def initialize expr, aliaz = nil

--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -339,6 +339,13 @@ module Arel
         collector << ")"
       end
 
+      def visit_Arel_Nodes_Filter o, collector
+        visit o.left, collector
+        collector << " FILTER (WHERE "
+        visit o.right, collector
+        collector << ")"
+      end
+
       def visit_Arel_Nodes_Rows o, collector
         if o.expr
           collector << "ROWS "

--- a/test/nodes/test_filter.rb
+++ b/test/nodes/test_filter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'helper'
+
+describe Arel::Nodes::Filter do
+  it 'should add filter to expression' do
+    table = Arel::Table.new :users
+    table[:id].count.filter(table[:gdp_per_capita].gteq(40_000)).to_sql.must_be_like %{
+        COUNT("users"."id") FILTER (WHERE "users"."gdp_per_capita" >= 40000)
+      }
+  end
+
+  describe 'as' do
+    it 'should alias the expression' do
+      table = Arel::Table.new :users
+      table[:id].count.filter(table[:gdp_per_capita].gteq(40_000)).as('foo').to_sql.must_be_like %{
+        COUNT("users"."id") FILTER (WHERE "users"."gdp_per_capita" >= 40000) AS foo
+      }
+    end
+  end
+
+  describe 'over' do
+    it 'should reference the window definition by name' do
+      table = Arel::Table.new :users
+      window = Arel::Nodes::Window.new.partition(table[:year])
+      table[:id].count.filter(table[:gdp_per_capita].gteq(40_000)).over(window).to_sql.must_be_like %{
+        COUNT("users"."id") FILTER (WHERE "users"."gdp_per_capita" >= 40000) OVER (PARTITION BY "users"."year")
+      }
+    end
+  end
+end


### PR DESCRIPTION
Closes #460

Currently supported only by PostgreSQL 9.4 and newer.

See:

 - http://modern-sql.com/feature/filter
 - https://www.postgresql.org/docs/9.4/static/sql-expressions.html#SYNTAX-AGGREGATES

Example (ActiveRecord):

```ruby
Model.all.pluck(
  Arel.star.count.as('records_total'),
  Arel.star.count.filter(Model.arel_table[:some_column].not_eq(nil)).as('records_filtered'),
)
```
  