### PR TITLE
Allow NamedFunction as the right side of Assignment

### DIFF
--- a/lib/arel/visitors/to_sql.rb
+++ b/lib/arel/visitors/to_sql.rb
@@ -642,14 +642,13 @@ module Arel
       end
 
       def visit_Arel_Nodes_Assignment o, collector
+        collector = visit o.left, collector
+        collector << " = "
+
         case o.right
-        when Arel::Nodes::UnqualifiedColumn, Arel::Attributes::Attribute, Arel::Nodes::BindParam
-          collector = visit o.left, collector
-          collector << " = "
+        when Arel::Nodes::UnqualifiedColumn, Arel::Attributes::Attribute, Arel::Nodes::BindParam, Arel::Nodes::NamedFunction
           visit o.right, collector
         else
-          collector = visit o.left, collector
-          collector << " = "
           collector << quote(o.right).to_s
         end
       end

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -284,6 +284,17 @@ module Arel
         }
       end
 
+      it "should visit_Arel_Nodes_Assignment with named function" do
+        column = @table["text"]
+        node = Nodes::Assignment.new(
+          Nodes::UnqualifiedColumn.new(column),
+          Nodes::NamedFunction.new('TRIM', [Nodes::UnqualifiedColumn.new(column)])
+        )
+        compile(node).must_be_like %{
+          "text" = TRIM("text")
+        }
+      end
+
       it "should visit visit_Arel_Attributes_Time" do
         attr = Attributes::Time.new(@attr.relation, @attr.name)
         compile attr


### PR DESCRIPTION
This PR enhances the `Assignment` node to allow a `NamedFunction` on the right side. This allows the `UpdateManager` to construct queries like `UPDATE my_table SET my_column = TRIM(my_column)`, which we wanted to do for a dynamic query in a migration recently.