### PR TITLE
Remove math module from count

### DIFF
--- a/lib/arel/nodes/count.rb
+++ b/lib/arel/nodes/count.rb
@@ -2,8 +2,6 @@
 module Arel
   module Nodes
     class Count < Arel::Nodes::Function
-      include Math
-
       def initialize expr, distinct = false, aliaz = nil
         super(expr, aliaz)
         @distinct = distinct


### PR DESCRIPTION
Not required after #449 has been merged.
There is still a spec https://github.com/rails/arel/blob/master/test/nodes/test_count.rb#L35-L41 to show it isn't needed.

Following on from https://github.com/rails/arel/pull/455#issuecomment-371210858