### PR TITLE
Boolean equality comparisons now use IS TRUE and IS FALSE for PostgreSQL and MySQL

### DIFF
--- a/lib/arel/visitors/mysql.rb
+++ b/lib/arel/visitors/mysql.rb
@@ -81,6 +81,34 @@ module Arel
         collector << ") "
         collector
       end
+
+      def visit_Arel_Nodes_Equality o, collector
+        right = o.right
+
+        return super(o, collector) unless [true, false].include?(right)
+
+        collector = visit o.left, collector
+
+        if right
+          collector << " IS TRUE"
+        else
+          collector << " IS FALSE"
+        end
+      end
+
+      def visit_Arel_Nodes_NotEqual o, collector
+        right = o.right
+
+        return super(o, collector) unless [true, false].include?(right)
+
+        collector = visit o.left, collector
+
+        if right
+          collector << " IS NOT TRUE"
+        else
+          collector << " IS NOT FALSE"
+        end
+      end
     end
   end
 end

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -46,6 +46,34 @@ module Arel
         visit(o.expr, collector) << " )"
       end
 
+      def visit_Arel_Nodes_Equality o, collector
+        right = o.right
+
+        return super(o, collector) unless [true, false].include?(right)
+
+        collector = visit o.left, collector
+
+        if right
+          collector << " IS TRUE"
+        else
+          collector << " IS FALSE"
+        end
+      end
+
+      def visit_Arel_Nodes_NotEqual o, collector
+        right = o.right
+
+        return super(o, collector) unless [true, false].include?(right)
+
+        collector = visit o.left, collector
+
+        if right
+          collector << " IS NOT TRUE"
+        else
+          collector << " IS NOT FALSE"
+        end
+      end
+
       def visit_Arel_Nodes_BindParam o, collector
         collector.add_bind(o.value) { |i| "$#{i}" }
       end

--- a/test/visitors/test_mysql.rb
+++ b/test/visitors/test_mysql.rb
@@ -74,6 +74,56 @@ module Arel
           }
         end
       end
+
+      describe 'Nodes::Equality' do
+        before do
+          @table = Table.new(:users)
+        end
+
+        it "should escape strings" do
+          test = @table[:name].eq 'Aaron Patterson'
+          compile(test).must_be_like %{
+            "users"."name" = 'Aaron Patterson'
+          }
+        end
+
+        it 'should handle true' do
+          sql = compile Nodes::Equality.new(@table[:active], true)
+          sql.must_be_like %{ "users"."active" IS TRUE }
+        end
+
+        it 'should handle false' do
+          sql = compile Nodes::Equality.new(@table[:active], false)
+          sql.must_be_like %{ "users"."active" IS FALSE }
+        end
+
+        it 'should handle nil' do
+          sql = compile Nodes::Equality.new(@table[:name], nil)
+          sql.must_be_like %{ "users"."name" IS NULL }
+        end
+      end
+
+      describe 'Nodes::NotEqual' do
+        before do
+          @table = Table.new(:users)
+        end
+
+        it 'should handle true' do
+          sql = compile Nodes::NotEqual.new(@table[:active], true)
+          sql.must_be_like %{ "users"."active" IS NOT TRUE }
+        end
+
+        it 'should handle false' do
+          sql = compile Nodes::NotEqual.new(@table[:active], false)
+          sql.must_be_like %{ "users"."active" IS NOT FALSE }
+        end
+
+        it 'should handle nil' do
+          val = Nodes.build_quoted(nil, @table[:active])
+          sql = compile Nodes::NotEqual.new(@table[:name], val)
+          sql.must_be_like %{ "users"."name" IS NOT NULL }
+        end
+      end
     end
   end
 end

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -188,6 +188,48 @@ module Arel
         end
       end
 
+      describe 'Nodes::Equality' do
+        it "should escape strings" do
+          test = Table.new(:users)[:name].eq 'Aaron Patterson'
+          compile(test).must_be_like %{
+            "users"."name" = 'Aaron Patterson'
+          }
+        end
+
+        it 'should handle true' do
+          sql = compile Nodes::Equality.new(@table[:active], true)
+          sql.must_be_like %{ "users"."active" IS TRUE }
+        end
+
+        it 'should handle false' do
+          sql = compile Nodes::Equality.new(@table[:active], false)
+          sql.must_be_like %{ "users"."active" IS FALSE }
+        end
+
+        it 'should handle nil' do
+          sql = compile Nodes::Equality.new(@table[:name], nil)
+          sql.must_be_like %{ "users"."name" IS NULL }
+        end
+      end
+
+      describe 'Nodes::NotEqual' do
+        it 'should handle true' do
+          sql = compile Nodes::NotEqual.new(@table[:active], true)
+          sql.must_be_like %{ "users"."active" IS NOT TRUE }
+        end
+
+        it 'should handle false' do
+          sql = compile Nodes::NotEqual.new(@table[:active], false)
+          sql.must_be_like %{ "users"."active" IS NOT FALSE }
+        end
+
+        it 'should handle nil' do
+          val = Nodes.build_quoted(nil, @table[:active])
+          sql = compile Nodes::NotEqual.new(@table[:name], val)
+          sql.must_be_like %{ "users"."name" IS NOT NULL }
+        end
+      end
+
       describe "Nodes::BindParam" do
         it "increments each bind param" do
           query = @table[:name].eq(Arel::Nodes::BindParam.new(1))

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -190,7 +190,7 @@ module Arel
 
       describe 'Nodes::Equality' do
         it "should escape strings" do
-          test = Table.new(:users)[:name].eq 'Aaron Patterson'
+          test = @table[:name].eq 'Aaron Patterson'
           compile(test).must_be_like %{
             "users"."name" = 'Aaron Patterson'
           }

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -123,8 +123,8 @@ module Arel
         it 'should handle false' do
           table = Table.new(:users)
           val = Nodes.build_quoted(false, table[:active])
-          sql = compile Nodes::Equality.new(val, val)
-          sql.must_be_like %{ 'f' = 'f' }
+          sql = compile Nodes::Equality.new(table[:active], val)
+          sql.must_be_like %{ "users"."active" = 'f' }
         end
 
         it 'should handle nil' do


### PR DESCRIPTION
This brings comparisons against booleans in sync with comparisons
against null values

https://www.postgresql.org/docs/9.3/static/functions-comparison.html

For the reasoning behind this, try the following:
* Given a User table with one nullable boolean field named "active", create 3 users with the following values for the active field: true, false, nil

Before this pull request, the Equality and NotEqual nodes generated this SQL with the following results:
* `SELECT COUNT(*) FROM users WHERE users.active = FALSE` returns 1 record (active == false only)
* `SELECT COUNT(*) FROM users WHERE users.active != FALSE` returns 1 record (active == true only i.e. active != false but only counting not-nullable columns)

The new approach seems to be more logical but feel free to let me know if it doesn't fit with the arel thinking:
* `SELECT COUNT(*) FROM users WHERE users.active IS FALSE` returns 1 record (active == false only)
* `SELECT COUNT(*) FROM users WHERE users.active IS NOT FALSE` returns 2 records (active == true and active == null which seems to be a better version of active != false)