### PR TITLE
Handle Oracle IN conditions with more than 1000 items

### DIFF
--- a/lib/arel/visitors/oracle.rb
+++ b/lib/arel/visitors/oracle.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
+
+require "arel/visitors/oracle_in_condition"
+
 module Arel
   module Visitors
     class Oracle < Arel::Visitors::ToSql
+      include OracleInCondition
+
       private
 
       def visit_Arel_Nodes_SelectStatement o, collector

--- a/lib/arel/visitors/oracle12.rb
+++ b/lib/arel/visitors/oracle12.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
+
+require "arel/visitors/oracle_in_condition"
+
 module Arel
   module Visitors
     class Oracle12 < Arel::Visitors::ToSql
+      include OracleInCondition
+
       private
 
       def visit_Arel_Nodes_SelectStatement o, collector

--- a/lib/arel/visitors/oracle_in_condition.rb
+++ b/lib/arel/visitors/oracle_in_condition.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+module Arel
+  module Visitors
+    module OracleInCondition
+      def self.in_condition_limit
+        1000
+      end
+
+      def visit_Arel_Nodes_In o, collector
+        if Array === o.right && o.right.empty?
+          collector << '1=0'
+        else
+          collector << "("
+          first_slice = true
+          o.right.each_slice(OracleInCondition.in_condition_limit) do |slice|
+            if first_slice
+              first_slice = false
+            else
+              collector << " OR "
+            end
+            collector = visit o.left, collector
+            collector << " IN ("
+            collector = visit slice, collector
+            collector << ")"
+          end
+          collector << ")"
+        end
+      end
+
+      def visit_Arel_Nodes_NotIn o, collector
+        if Array === o.right && o.right.empty?
+          collector << '1=1'
+        else
+          collector << "("
+          first_slice = true
+          o.right.each_slice(OracleInCondition.in_condition_limit) do |slice|
+            if first_slice
+              first_slice = false
+            else
+              collector << " AND "
+            end
+            collector = visit o.left, collector
+            collector << " NOT IN ("
+            collector = visit slice, collector
+            collector << ")"
+          end
+          collector << ")"
+        end
+      end
+    end
+  end
+end
+

--- a/test/visitors/test_oracle.rb
+++ b/test/visitors/test_oracle.rb
@@ -191,6 +191,26 @@ module Arel
           }
         end
       end
+
+      describe "maxiumum in condition length" do
+        it "splits IN clause values into Arel::Visitors::OracleInCondition.in_condition_limit sized chunks" do
+          Arel::Visitors::OracleInCondition.stub :in_condition_limit, 5 do
+            node = @table[:id].in([1, 2, 3, 4, 5, 6, 7, 8])
+            compile(node).must_be_like %{
+              ("users"."id" IN (1, 2, 3, 4, 5) OR "users"."id" IN (6, 7, 8))
+            }
+          end
+        end
+
+        it "splits NOT IN condition values into Arel::Visitors::Oracle.in_clause_length sized chunks" do
+          Arel::Visitors::OracleInCondition.stub :in_condition_limit, 5 do
+            node = @table[:id].not_in([1, 2, 3, 4, 5, 6, 7, 8])
+            compile(node).must_be_like %{
+              ("users"."id" NOT IN (1, 2, 3, 4, 5) AND "users"."id" NOT IN (6, 7, 8))
+            }
+          end
+        end
+      end
     end
   end
 end

--- a/test/visitors/test_oracle12.rb
+++ b/test/visitors/test_oracle12.rb
@@ -55,6 +55,26 @@ module Arel
           }
         end
       end
+
+      describe "maxiumum in condition length" do
+        it "splits IN clause values into Arel::Visitors::OracleInCondition.in_condition_limit sized chunks" do
+          Arel::Visitors::OracleInCondition.stub :in_condition_limit, 5 do
+            node = @table[:id].in([1, 2, 3, 4, 5, 6, 7, 8])
+            compile(node).must_be_like %{
+              ("users"."id" IN (1, 2, 3, 4, 5) OR "users"."id" IN (6, 7, 8))
+            }
+          end
+        end
+
+        it "splits NOT IN condition values into Arel::Visitors::Oracle.in_clause_length sized chunks" do
+          Arel::Visitors::OracleInCondition.stub :in_condition_limit, 5 do
+            node = @table[:id].not_in([1, 2, 3, 4, 5, 6, 7, 8])
+            compile(node).must_be_like %{
+              ("users"."id" NOT IN (1, 2, 3, 4, 5) AND "users"."id" NOT IN (6, 7, 8))
+            }
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Oracle has a limit of 1000 item in IN conditions. Supplying an IN/NOT IN condition with more than 1000 items results in an ORA-01795 error. This change splits IN/NOT IN condition values into 1000-item chunks for the `Oracle` and `Oracle12` visitors.

I think the introduction of the `Arel::Visitors::OracleInCondition` module is a little weird when it sits next to the other visitor classes, but it seemed better than duplicating the code.

Thanks for considering!