### PR TITLE
Add special treatment for an In node where the right side is [nil, true/false]

### DIFF
--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -46,12 +46,12 @@ module Arel
         visit(o.expr, collector) << " )"
       end
 
-      def visit_Arel_Nodes_NotIn o, collector
+      def visit_Arel_Nodes_In o, collector
         return super(o, collector) unless Array === o.right && o.right.size == 2
 
         sorted_right = o.right.map(&:val).sort { |element| element.nil? ? -1 : 1 }
-        is_not_true = [nil, true] == sorted_right
-        is_not_false = [nil, false] == sorted_right
+        is_not_true = [nil, false] == sorted_right
+        is_not_false = [nil, true] == sorted_right
 
         return super(o, collector) unless is_not_true || is_not_false
 

--- a/test/visitors/test_to_sql.rb
+++ b/test/visitors/test_to_sql.rb
@@ -123,8 +123,8 @@ module Arel
         it 'should handle false' do
           table = Table.new(:users)
           val = Nodes.build_quoted(false, table[:active])
-          sql = compile Nodes::Equality.new(val, val)
-          sql.must_be_like %{ 'f' = 'f' }
+          sql = compile Nodes::Equality.new(table[:active], val)
+          sql.must_be_like %{ "users"."active" = 'f' }
         end
 
         it 'should handle nil' do


### PR DESCRIPTION
This allows us to generate special SQL for a NotIn node which contains
just a two element array that consists solely of nil and either true
or false.

Translated to ActiveRecord, this means that
```ruby
  User.where(active: [nil, true])
```
will generate:
```sql
  SELECT * FROM "users" WHERE "users"."active" IS NOT FALSE;
```
instead of the old:
```sql
  SELECT * from "users" WHERE "users"."active" IS NULL OR "users"."active" = true
```
and
```ruby
  User.where(active: [nil, false])
```
will generate:
```sql
  SELECT * FROM "users" WHERE "users"."active" IS NOT TRUE;
```