### PR TITLE
Avoid Ruby 2.6 style warnings

### DIFF
--- a/lib/arel/nodes/casted.rb
+++ b/lib/arel/nodes/casted.rb
@@ -30,15 +30,15 @@ module Arel
 
     def self.build_quoted other, attribute = nil
       case other
-        when Arel::Nodes::Node, Arel::Attributes::Attribute, Arel::Table, Arel::Nodes::BindParam, Arel::SelectManager, Arel::Nodes::Quoted, Arel::Nodes::SqlLiteral
-          other
+      when Arel::Nodes::Node, Arel::Attributes::Attribute, Arel::Table, Arel::Nodes::BindParam, Arel::SelectManager, Arel::Nodes::Quoted, Arel::Nodes::SqlLiteral
+        other
+      else
+        case attribute
+        when Arel::Attributes::Attribute
+          Casted.new other, attribute
         else
-          case attribute
-            when Arel::Attributes::Attribute
-              Casted.new other, attribute
-            else
-              Quoted.new other
-          end
+          Quoted.new other
+        end
       end
     end
   end


### PR DESCRIPTION
Before:

```
arel]$ bundle exec rake
~/.rbenv/versions/2.6.0-dev/bin/ruby -w -I"lib:lib:test" ...
~/code/arel/lib/arel/nodes/casted.rb:33: warning: mismatched indentations at 'when' with 'case' at 32
~/code/arel/lib/arel/nodes/casted.rb:35: warning: mismatched indentations at 'else' with 'case' at 32
~/code/arel/lib/arel/nodes/casted.rb:37: warning: mismatched indentations at 'when' with 'case' at 36
~/code/arel/lib/arel/nodes/casted.rb:39: warning: mismatched indentations at 'else' with 'case' at 36
Run options: ...
```

After:

```
arel]$ bundle exec rake
~/.rbenv/versions/2.6.0-dev/bin/ruby -w -I"lib:lib:test" ...
Run options: ...
```